### PR TITLE
Temporarily remove call to `send_retry_message`

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -125,7 +125,7 @@ def handler(event, context):
 
     except BaseException:
         # Send retry message to sqs
-        send_retry_message(message, sqs_client)
+        # send_retry_message(message, sqs_client)
         # Raise error up to ensure it's logged
         raise
 


### PR DESCRIPTION
We are still testing the main ingester code, errors thrown by the retry code
are swallowing other errors. Don't retry for now - renable this once we have
ingestion working.