### PR TITLE
add job to deploy to production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,21 @@
+name: Deploy lambda to AWS (production)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: aws-actions/setup-sam@v1
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_PRODUCTION_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_PRODUCTION_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - run: sam build --use-container -m requirements/base.txt
+      - run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name ds-caselaw-ingester --s3-bucket tna-caselaw-ingester-deploy --capabilities CAPABILITY_IAM --region eu-west-2


### PR DESCRIPTION
For now, deploy everything on main, but we can change this to tags-only later. I've added the secrets to the build environment already.