### PR TITLE
Register namespaces before parsing XML so that they don't get stripped

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -161,6 +161,8 @@ def handler(event, context):
 
         contents = xml_file.read()
 
+        ET.register_namespace("", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0")
+        ET.register_namespace("uk", "https://caselaw.nationalarchives.gov.uk/akn")
         xml = ET.XML(contents)
 
         try:


### PR DESCRIPTION
This is a quick fix for our namespace issue in https://trello.com/c/soelnO6d. The document is parsed but the parser isn't aware of the namespaces and throws them away. Thanks, XML. This fix registers the namespaces before parsing, so that they aren't discarded.

This is *not* the proper fix though. The document is parsed, then immediately serialized again for inserting (when it's parsed again inside marklogic). We should refactior https://github.com/nationalarchives/ds-caselaw-custom-api-client/blob/main/src/caselawclient/Client.py#L189 and https://github.com/nationalarchives/ds-caselaw-custom-api-client/blob/main/src/caselawclient/Client.py#L170 to expose versions that don't serialize, and that accept a string instead of an XML document. However, I'm inclined to release the quick fix now, then treat that as a technical debt ticket for later.