### PR TITLE
Throw a UriNotFoundException if the URI is not part of the message

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -39,8 +39,12 @@ class MaximumRetriesExceededException(Exception):
     pass
 
 
-def extract_uri(metadata: dict) -> str:
-    return metadata["parameters"]["PARSER"]["uri"].replace('https://caselaw.nationalarchives.gov.uk/id/', '')
+def extract_uri(metadata: dict, consignment_reference: str) -> str:
+    uri = metadata["parameters"]["PARSER"]["uri"]
+    if not uri:
+        raise UriNotFoundException(f'URI not found. Consignment Ref: {consignment_reference}')
+
+    return uri.replace('https://caselaw.nationalarchives.gov.uk/id/', '')
 
 
 def extract_docx_filename(metadata: dict) -> str:
@@ -166,7 +170,7 @@ def handler(event, context):
         xml_file_name = metadata["parameters"]["TRE"]["payload"]["xml"]
         xml_file = tar.extractfile(f'{consignment_reference}/{xml_file_name}')
 
-        uri = extract_uri(metadata)
+        uri = extract_uri(metadata, consignment_reference)
 
         if not uri:
             raise UriNotFoundException(f'URI not found. Consignment Ref: {consignment_reference}')


### PR DESCRIPTION
Rollbar: https://rollbar.com/dxw/tna-caselaw-ingester/items/23/

```
AttributeError: 'NoneType' object has no attribute 'replace' (Most recent call last)
File /var/task/lambda_function.py line 154 in handler args locals
uri = extract_uri(metadata)
File /var/task/lambda_function.py line 43 in extract_uri args locals
'return metadata["parameters"]["PARSER"]["uri"]....s://caselaw.nationalarchives.gov.uk/id/\', \'\')'
```

If the metadata JSON doesn't contain any reference to a uri, the lambda is
erroring without throwing a UriNotFoundException, because it can't perform a
`replace` on a non-existent object. Move the UriNotFoundException up into the
`extract_uri` method to catch this error.