### PR TITLE
Only send a retry message if we cannot access the Tarball from s3

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -215,10 +215,12 @@ def handler(event, context):
         # Copy original tarfile
         store_file(open(filename, mode='rb'), uri, os.path.basename(filename), s3_client)
 
-    except BaseException:
+    except urllib3.exceptions.ProtocolError:
         # Send retry message to sqs
         send_retry_message(message, sqs_client)
         # Raise error up to ensure it's logged
+        raise
+    except BaseException:
         raise
 
     return message


### PR DESCRIPTION
Other exceptions should be raised to Rollbar but not trigger retries

Trello: https://trello.com/c/eC7a2yUL/474-dont-retry-ingestions-that-have-a-missing-uri-or-other-fields-it-wont-help