### PR TITLE
Create a `failure` URI and document in Marklogic if there is no URI in the consignment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,15 @@ services:
     image: localstack/localstack
     network_mode: bridge
     environment:
-      SERVICES: lambda,sns,s3,sqs
+      SERVICES: lambda,sns,s3,sqs,iam
       DEBUG: 1
     ports:
       - 4566:4566
     volumes:
       - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
+
+networks:
+  default:
+    external:
+      name: caselaw

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -8,6 +8,7 @@ from boto3.session import Session
 import urllib3
 import tarfile
 import xml.etree.ElementTree as ET
+from xml.sax.saxutils import escape
 
 from caselawclient.Client import api_client, MarklogicCommunicationError, MarklogicResourceNotFoundError
 from botocore.exceptions import NoCredentialsError
@@ -135,7 +136,7 @@ def send_retry_message(original_message: Dict[str, Union[str, int]], sqs_client:
 
 def create_error_xml_contents(tar, consignment_reference: str):
     parser_log = tar.extractfile(f'{consignment_reference}/parser.log')
-    parser_log_contents = parser_log.read().decode('utf-8')
+    parser_log_contents = escape(parser_log.read().decode('utf-8'))
     return f'<error>{parser_log_contents}</error>'
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ==0.8.1
-ds-caselaw-marklogic-api-client~=4.3
+ds-caselaw-marklogic-api-client~=4.5.2
 requests-toolbelt==0.9.1
 urllib3==1.26.9
 boto3


### PR DESCRIPTION
If the consignment from TRE does not contain a URI, or only contains the stem of a URI, create a `failure` uri from the consignment reference. Use this uri to store a document in Marklogic, either the document XML (if it exists) or a dummy XML document with the parser log output in it if not.

All other documents in the tarball should be processed and stored as normal (if they exist). 