### PR TITLE
Send a retry message on tarfile.ReadError

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -221,7 +221,7 @@ def handler(event, context):
         # Copy original tarfile
         store_file(open(filename, mode='rb'), uri, os.path.basename(filename), s3_client)
 
-    except urllib3.exceptions.ProtocolError:
+    except (urllib3.exceptions.ProtocolError, tarfile.ReadError):
         # Send retry message to sqs
         send_retry_message(message, sqs_client)
         # Raise error up to ensure it's logged


### PR DESCRIPTION
exception caught by Rollbar:
```
ReadError: file could not be opened successfully (Most recent call last)
File /var/task/lambda_function.py line 170 in handler args locals
tar = tarfile.open(filename, mode='r')
File /var/lang/lib/python3.9/tarfile.py line 1625 in open args locals
raise ReadError("file could not be opened successfully")
ReadError: file could not be opened successfully
```

When the tarball cannot be read, send a retry message to the queue.