### PR TITLE
Make retry maximum configurable via ENV

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -118,13 +118,13 @@ def copy_file(tarfile, input_filename, output_filename, uri, s3_client: Session.
         raise FileNotFoundException(f'File was not found: {input_filename}')
 
 def send_retry_message(original_message: Dict[str, Union[str, int]], sqs_client: Session.client) -> None:
-    number_of_retries = int(original_message["number-of-retries"])
-    if number_of_retries <= 3:
+    retry_number = int(original_message["number-of-retries"]) + 1
+    if retry_number <= int(os.getenv("MAX_RETRIES")):
         retry_message = {
             "consignment-reference": original_message["consignment-reference"],
             "s3-folder-url": "",
             "consignment-type": original_message["consignment-type"],
-            "number-of-retries": number_of_retries + 1
+            "number-of-retries": retry_number
         }
         sqs_client.send_message(
             QueueUrl=os.getenv('SQS_QUEUE_URL'),

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -119,7 +119,7 @@ def copy_file(tarfile, input_filename, output_filename, uri, s3_client: Session.
 
 def send_retry_message(original_message: Dict[str, Union[str, int]], sqs_client: Session.client) -> None:
     retry_number = int(original_message["number-of-retries"]) + 1
-    if retry_number <= int(os.getenv("MAX_RETRIES")):
+    if retry_number <= int(os.getenv("MAX_RETRIES", "5")):
         retry_message = {
             "consignment-reference": original_message["consignment-reference"],
             "s3-folder-url": "",


### PR DESCRIPTION
Situation:

1. We now don't retry on all errors
2. We throw an error if we've reached the max retry count
3. TRE complains if the retry counts don't match what it expects

This means that existing ingestions that failed and hit the retry limit can't be manually triggered any more. To fix this, I want to bump up our retry limit for a while, then put it back when we've processed everything that was stuck. I thought the best way would be to move it into the ENV. I've set this ENV var on both lambda environments already.

I thought the code was a little clearer the way I've written it and named things, sorry if it's awkward to parse in your brain to make sure it does the same thing!