### PR TITLE
Correctly return a "failure" uri if the uri partially present in meta…

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -39,10 +39,13 @@ class MaximumRetriesExceededException(Exception):
 def extract_uri(metadata: dict, consignment_reference: str) -> str:
     uri = metadata["parameters"]["PARSER"].get("uri", "")
 
+    if uri:
+        uri = uri.replace("https://caselaw.nationalarchives.gov.uk/id/", "")
+
     if not uri:
         uri = f'failures/{consignment_reference}'
 
-    return uri.replace('https://caselaw.nationalarchives.gov.uk/id/', '')
+    return uri
 
 
 def extract_docx_filename(metadata: dict) -> str:


### PR DESCRIPTION
…data

We had an issue with a judgment where the uri was partially present in the
metadata file, e.g.

```
"PARSER": {
          "uri": "https://caselaw.nationalarchives.gov.uk/id/"
```

While we believe this had been accounted for in an earlier commit, in actual
fact it was not, and the uri was passed through the ingester as
`"https://caselaw.nationalarchives.gov.uk/id/"`; this resulted in the document
being stored in Marklogic under the uri `"/"`

This commit is a little clunky but accounts for all possibilities:
1) The uri is present as `https://caselaw.nationalarchives.gov.uk/id/xxx/xxx/xxx` (correct)
2) The uri is present as `https://caselaw.nationalarchives.gov.uk/id/` (incorrect)
3) The uri key is present but its value is `null` (incorrect)
4) The uri key is completely missing (incorrect)