### PR TITLE
Treat the absence of `parser.log` as a non-fatal error

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -138,9 +138,12 @@ def send_retry_message(original_message: Dict[str, Union[str, int]], sqs_client:
 
 
 def create_error_xml_contents(tar, consignment_reference: str):
-    parser_log = tar.extractfile(f'{consignment_reference}/parser.log')
-    parser_log_contents = escape(parser_log.read().decode('utf-8'))
-    return f'<error>{parser_log_contents}</error>'
+    try:
+        parser_log = tar.extractfile(f'{consignment_reference}/parser.log')
+        parser_log_contents = escape(parser_log.read().decode('utf-8'))
+        return f'<error>{parser_log_contents}</error>'
+    except KeyError:
+        return "<error>parser.log not found</error>"
 
 
 @rollbar.lambda_function


### PR DESCRIPTION
Rollbar was catching this exception if `parser.log` is not present:

```
Traceback (most recent call last):
1
File "/var/task/lambda_function.py" line 188 in handler [args] [locals]
contents = create_error_xml_contents(tar, consignment_reference)
2
File "/var/task/lambda_function.py" line 141 in create_error_xml_contents [args] [locals]
parser_log = tar.extractfile(f'{consignment_reference}/parser.log')
3
File "/var/lang/lib/python3.9/tarfile.py" line 2113 in extractfile [args] [locals]
tarinfo = self.getmember(member)
4
File "/var/lang/lib/python3.9/tarfile.py" line 1799 in getmember [args] [locals]
raise KeyError("filename %r not found" % name)
KeyError: "filename 'TDR-2022-2M/parser.log' not found"
```

If `parser.log` is not present, don't treat this as a fatal error - the judgment
can still be processed as a "failure" and displayed in the Editor UI.

Replace the contents of the parser log with an information message and allow the
judgment to be processed as a "failure" document.