### PR TITLE
Don't raise ReadError or ProtocolError to Rollbar

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -249,8 +249,6 @@ def handler(event, context):
     except (urllib3.exceptions.ProtocolError, tarfile.ReadError):
         # Send retry message to sqs
         send_retry_message(message, sqs_client)
-        # Raise error up to ensure it's logged
-        raise
     except BaseException:
         raise
 


### PR DESCRIPTION
If a ReadError or ProtocolError is thrown, we want to retry ingesting the
file - we don't necessarily need to know this has happend in Rollbar. We only
need to raise errors in Rollbar if the maximum retries are exceeded, or if
another error is thrown.

This should reduce some of the noise in Rollbar for the ingester.