### PR TITLE
Don't raise an error if parser.log not found

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -238,7 +238,10 @@ def handler(event, context):
     copy_file(tar, f'{consignment_reference}/{docx_filename}', f'{uri.replace("/", "_")}.docx', uri, s3_client)
 
     # Store parser log
-    copy_file(tar, f'{consignment_reference}/parser.log', 'parser.log', uri, s3_client)
+    try:
+        copy_file(tar, f'{consignment_reference}/parser.log', 'parser.log', uri, s3_client)
+    except KeyError:
+        pass
 
     # Store images
     for image_filename in metadata["parameters"]["TRE"]["payload"]["images"]:


### PR DESCRIPTION

<!-- Amend as appropriate -->

## Changes in this PR:

Don't throw a KeyError if `parser.log` isn't in the tarball. This isn't a
fatal error, we can still ingest the file as a `failure`.

## Trello card / Rollbar error (etc)

Rollbar: https://rollbar.com/dxw/tna-caselaw-ingester/items/30/

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
