### PR TITLE
Refactor editor notification flow for new/updated judgments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+        args: ["--profile", "black", "--filter-files"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -11,8 +11,11 @@ import rollbar
 import urllib3
 from boto3.session import Session
 from botocore.exceptions import NoCredentialsError
-from caselawclient.Client import (MarklogicCommunicationError,
-                                  MarklogicResourceNotFoundError, api_client)
+from caselawclient.Client import (
+    MarklogicCommunicationError,
+    MarklogicResourceNotFoundError,
+    api_client,
+)
 from notifications_python_client.notifications import NotificationsAPIClient
 
 rollbar.init(os.getenv("ROLLBAR_TOKEN"), environment=os.getenv("ROLLBAR_ENV"))

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -320,7 +320,7 @@ def handler(event, context):
     if xml_file:
         contents = xml_file.read()
     elif "failures" in uri:
-        contents = create_error_xml_contents(tar, consignment_reference)
+        contents = create_error_xml_contents(tar)
     else:
         raise XmlFileNotFoundException(
             f"No XML file was found. Consignment Ref: {consignment_reference}"

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -11,7 +11,8 @@ import rollbar
 import urllib3
 from boto3.session import Session
 from botocore.exceptions import NoCredentialsError
-from caselawclient.Client import MarklogicResourceNotFoundError, api_client
+from caselawclient.Client import (MarklogicCommunicationError,
+                                  MarklogicResourceNotFoundError, api_client)
 from notifications_python_client.notifications import NotificationsAPIClient
 
 rollbar.init(os.getenv("ROLLBAR_TOKEN"), environment=os.getenv("ROLLBAR_ENV"))
@@ -38,6 +39,10 @@ class InvalidXMLException(Exception):
 
 
 class InvalidMessageException(Exception):
+    pass
+
+
+class DocumentInsertionError(Exception):
     pass
 
 
@@ -239,6 +244,34 @@ def update_published_documents(uri, s3_client):
             s3_client.copy(source, public_bucket, key, extra_args)
 
 
+def parse_xml_contents(contents, uri, tarfile_name) -> ET.Element:
+    try:
+        ET.register_namespace("", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0")
+        ET.register_namespace("uk", "https://caselaw.nationalarchives.gov.uk/akn")
+        return ET.XML(contents)
+    except ET.ParseError:
+        raise InvalidXMLException(
+            f"Invalid XML in tarfile. URI: {uri}, tarfile: {tarfile_name}"
+        )
+
+
+def update_judgment_xml(uri, xml) -> bool:
+    try:
+        api_client.get_judgment_xml(uri, show_unpublished=True)
+        api_client.save_judgment_xml(uri, xml)
+        return True
+    except (MarklogicResourceNotFoundError, MarklogicCommunicationError):
+        return False
+
+
+def insert_judgment_xml(uri, xml) -> bool:
+    try:
+        api_client.insert_judgment_xml(uri, xml)
+        return True
+    except MarklogicCommunicationError:
+        return False
+
+
 @rollbar.lambda_function
 def handler(event, context):
     decoder = json.decoder.JSONDecoder()
@@ -293,26 +326,22 @@ def handler(event, context):
             f"No XML file was found. Consignment Ref: {consignment_reference}"
         )
 
-    ET.register_namespace("", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0")
-    ET.register_namespace("uk", "https://caselaw.nationalarchives.gov.uk/akn")
+    xml = parse_xml_contents(contents, uri, tar.name)
 
-    try:
-        xml = ET.XML(contents)
-        api_client.get_judgment_xml(uri, show_unpublished=True)
-        api_client.save_judgment_xml(uri, xml)
+    updated = update_judgment_xml(uri, xml)
+    inserted = False if updated else insert_judgment_xml(uri, xml)
 
+    if updated:
         # Notify editors that a document has been updated
         send_updated_judgment_notification(uri, metadata)
         print(f"Updated judgment {uri}")
-    except MarklogicResourceNotFoundError:
-        xml = ET.XML(contents)
-        api_client.insert_judgment_xml(uri, xml)
+    elif inserted:
         # Notify editors that a new document is ready
         send_new_judgment_notification(uri, metadata)
         print(f"Inserted judgment {uri}")
-    except ET.ParseError:
-        raise InvalidXMLException(
-            f"Invalid XML in tarfile. URI: {uri}, tarfile: {tar.name}"
+    else:
+        raise DocumentInsertionError(
+            f"Judgment {uri} failed to insert into Marklogic. Consignment Ref: {consignment_reference}"
         )
 
     # Store metadata

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -7,8 +7,11 @@ from unittest.mock import ANY, MagicMock, call, patch
 import boto3
 from botocore.exceptions import NoCredentialsError
 from callee import Contains
-from caselawclient.Client import (MarklogicCommunicationError,
-                                  MarklogicResourceNotFoundError, api_client)
+from caselawclient.Client import (
+    MarklogicCommunicationError,
+    MarklogicResourceNotFoundError,
+    api_client,
+)
 from notifications_python_client.notifications import NotificationsAPIClient
 
 from . import lambda_function

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,11 @@
 max-line-length = 120
 
 [flake8]
-ignore: E722,W503
+ignore: E722,W503,I001,I005
 max-line-length = 120
 
 [tool:pytest]
 norecursedirs = package/*
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Editors were receiving occasional notifications of a new judgment, but the
attached link to the editorial UI lead to a 404 page. On investigation,
it appears two judgments have generated this email but are not in Marklogic.

In order to track down why this might be happening, we have refactored the
judgment insertion/update flow. There is a possibility the call to
`api_client.insert_judgment_xml` was failing, but not exception was being
caught and the notification of a new judgment was being sent anyway.

This refactor should hopefully catch any errors with updating/inserting a
judgment and not allow a notification to be sent if either fails.

This refactor also adds some new tests.

## Trello card / Rollbar error (etc)

Trello: https://trello.com/c/hfOotu2k

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
