### PR TITLE
Add check to guard against an empty XML file name

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -48,9 +48,10 @@ class DocumentInsertionError(Exception):
 
 def extract_xml_file(tar: tarfile, xml_file_name: str):
     xml_file = None
-    for member in tar.getmembers():
-        if xml_file_name in member.name:
-            xml_file = tar.extractfile(member)
+    if xml_file_name:
+        for member in tar.getmembers():
+            if xml_file_name in member.name:
+                xml_file = tar.extractfile(member)
 
     return xml_file
 
@@ -282,7 +283,8 @@ def get_best_xml(uri, tar, xml_file_name, consignment_reference):
             return parse_xml(contents)
     else:
         logging.warning(
-            f"No XML file found in tarfile for uri: {uri}, consignment reference: {consignment_reference}."
+            f"No XML file found in tarfile for uri: {uri}, filename: {xml_file_name},"
+            f"consignment reference: {consignment_reference}."
             f" Falling back to parser.log contents."
         )
         contents = create_parser_log_xml(tar)

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -76,6 +76,15 @@ class LambdaTest(unittest.TestCase):
         result = lambda_function.extract_xml_file(tar, filename)
         assert result is None
 
+    def test_extract_xml_file_name_empty(self):
+        filename = ""
+        tar = tarfile.open(
+            self.TDR_TARBALL_PATH,
+            mode="r",
+        )
+        result = lambda_function.extract_xml_file(tar, filename)
+        assert result is None
+
     def test_extract_metadata_success_tdr(self):
         consignment_reference = "TDR-2022-DNWR"
         tar = tarfile.open(


### PR DESCRIPTION

## Changes in this PR:

It looks like sometimes, the XML file name that's meant to be in the
metadata is not present. If this is the case, handle the exception and return
None, instead of raising an error.

<!-- Amend as appropriate -->


## Trello card / Rollbar error (etc)

Rollbar:

https://rollbar.com/dxw/tna-caselaw-ingester/items/39/?item_page=0&#traceback



<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
