### PR TITLE
Debugging more corner cases in the ingester

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -369,14 +369,16 @@ def handler(event, context):
         pass
 
     # Store images
-    for image_filename in metadata["parameters"]["TRE"]["payload"]["images"]:
-        copy_file(
-            tar,
-            f"{consignment_reference}/{image_filename}",
-            image_filename,
-            uri,
-            s3_client,
-        )
+    image_list = metadata["parameters"]["TRE"]["payload"]["images"]
+    if image_list:
+        for image_filename in image_list:
+            copy_file(
+                tar,
+                f"{consignment_reference}/{image_filename}",
+                image_filename,
+                uri,
+                s3_client,
+            )
 
     # Copy original tarfile
     store_file(open(filename, mode="rb"), uri, os.path.basename(filename), s3_client)

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -64,7 +64,6 @@ def extract_metadata(tar: tarfile, consignment_reference: str):
             te_metadata_file = tar.extractfile(member)
 
     if te_metadata_file is None:
-        tar.close()
         raise FileNotFoundException(
             f"Metadata file not found. Consignment Ref: {consignment_reference}"
         )
@@ -219,14 +218,11 @@ def send_retry_message(
 
 def create_parser_log_xml(tar):
     parser_log_value = "<error>parser.log not found</error>"
-    try:
-        for member in tar.getmembers():
-            if "parser.log" in member.name:
-                parser_log = tar.extractfile(member)
-                parser_log_contents = escape(parser_log.read().decode("utf-8"))
-                parser_log_value = f"<error>{parser_log_contents}</error>"
-    finally:
-        tar.close()
+    for member in tar.getmembers():
+        if "parser.log" in member.name:
+            parser_log = tar.extractfile(member)
+            parser_log_contents = escape(parser_log.read().decode("utf-8"))
+            parser_log_value = f"<error>{parser_log_contents}</error>"
     return parser_log_value
 
 
@@ -387,5 +383,7 @@ def handler(event, context):
 
     if api_client.get_published(uri):
         update_published_documents(uri, s3_client)
+
+    tar.close()
 
     return message

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -365,7 +365,7 @@ def handler(event, context):
         copy_file(
             tar, f"{consignment_reference}/parser.log", "parser.log", uri, s3_client
         )
-    except KeyError:
+    except FileNotFoundException:
         pass
 
     # Store images


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

On 21/07/22 we had 5 failures from TRE. On inspection, we found a few "corner cases" where the ingester lambda was not handling errors cleanly:

1) If there is no parser.log present, we were expecting to catch a KeyError from `copy_file()`. But `copy_file()` throws a custom FileNotFoundException, and we were not catching it. As a result, none of the tarfile contents were being saved to S3, because the lambda bombed out before the files could be copied.

2) We expect to iterate over a list of images in the metadata file and store those images. But if there is no `images` entry in the metadata JSON, the lambda was again throwing an uncaught exception. Again, this was causing the tarfile contents to not be saved to S3.

3) As a side-effect of the above two, the lambda was also throwing an error complaining of trying to read a closed tarfile (https://rollbar.com/dxw/tna-caselaw-ingester/items/43/). A small refactor here to only open and close the tarfile in one place (the handler function) should prevent this. 

## Trello card / Rollbar error (etc)

https://rollbar.com/dxw/tna-caselaw-ingester/items/43/
https://trello.com/c/GHBwl5xp

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
