### PR TITLE
Add a test to prove that we can extract a consignment ref from a presigned url

### DIFF
--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -410,6 +410,15 @@ class LambdaTest(unittest.TestCase):
         result = lambda_function.get_consignment_reference(message)
         assert result == "ewca_civ_2021_1881"
 
+    def test_get_consignment_reference_presigned_url(self):
+        message = {
+            "consignment-reference": "",
+            "s3-folder-url": "http://172.17.0.2:4566/te-editorial-out-int/"
+            "ewca_civ_2021_1881.tar.gz?randomstuffafterthefilename",
+        }
+        result = lambda_function.get_consignment_reference(message)
+        assert result == "ewca_civ_2021_1881"
+
     def test_malformed_message(self):
         message = {"something-unexpected": "???"}
         with self.assertRaises(lambda_function.InvalidMessageException):


### PR DESCRIPTION
https://trello.com/c/5GUPk9V7/1105-adjust-getconsignmentreference-in-ingester

We could already extract the consignment ref from a presigned URL, we just didn't have a test proving it!