### PR TITLE
If a judgment is updated, unpublish it

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -287,6 +287,10 @@ def get_best_xml(uri, tar, xml_file_name, consignment_reference):
         return parse_xml(contents)
 
 
+def unpublish_updated_judgment(uri):
+    api_client.set_published(uri, False)
+
+
 @rollbar.lambda_function
 def handler(event, context):
     decoder = json.decoder.JSONDecoder()
@@ -337,6 +341,7 @@ def handler(event, context):
     if updated:
         # Notify editors that a document has been updated
         send_updated_judgment_notification(uri, metadata)
+        unpublish_updated_judgment(uri)
         print(f"Updated judgment {uri}")
     elif inserted:
         # Notify editors that a new document is ready

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -538,3 +538,9 @@ class LambdaTest(unittest.TestCase):
             )
             assert result.__class__ == ET.Element
             assert result.tag == "error"
+
+    def test_unpublish_updated_judgment(self):
+        uri = "a/fake/uri"
+        api_client.set_published = MagicMock()
+        lambda_function.unpublish_updated_judgment(uri)
+        api_client.set_published.assert_called_with(uri, False)


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

Editors have requested that if a judgment is ingested and it is an update to an existing judgment, the judgment is unpublished. This is to prevent any unchecked judgments appearing on the Public UI. A judgment must be re-checked by the editors if it is an update.

## Trello card / Rollbar error (etc)

https://trello.com/c/5IUSmnjQ


<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
