### PR TITLE
Improve testing mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,16 @@ build:
 	@zip -g dist/lambda.zip ds-caselaw-ingester/lambda_function.py
 	@echo 'Built dist/lambda.zip'
 
+ifeq (setup,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "setup"
+  RUN_ARG := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARG):;@:)
+endif
+
 setup:
 	make build
-	sh scripts/setup-localstack.sh
+	sh scripts/setup-localstack.sh $(RUN_ARG)
 
 update:
 	make build

--- a/README.md
+++ b/README.md
@@ -84,13 +84,12 @@ make send-message
 
 To test a tarfile locally:
 
-1. Add your test tarfile to `aws_examples/s3/te-editorial-out-int`
+1. Add your test tarfile to `aws_examples/s3/te-editorial-out-int`.
 2. Edit `aws_examples/sns/parsed-judgment.json` to contain your tarfile name in `s3-folder-url` and consignment reference
-   in `consignment-reference`
-3. In `scripts/setup-localstack.sh`, change the line which begins `awslocal s3 cp aws_examples/s3/te-editorial-out-int/`
-   to contain your tarfile name, e.g. if your tarfile is called `XYZ-123.tar.gz`, this line should read
-   `awslocal s3 cp aws_examples/s3/te-editorial-out-int/XYZ-123.tar.gz s3://te-editorial-out-int`
-4. Run `make setup` and `make send-message` to ingest your tarfile
+   in `consignment-reference`.
+3. Run `make setup aws_examples/s3/te-editorial-out-int/<your tarfile>`, for example `make setup aws_examples/s3/te-editorial-out-int/XYZ-123.tar.gz`.
+   If you run `make setup` without an argument, the original test tarfile `TDR-2022-DNWR.tar.gz` will be used
+4. Run `make send-message` to ingest your tarfile.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ And then send a message:
 make send-message
 ```
 
+## Local testing
+
+To test a tarfile locally:
+
+1. Add your test tarfile to `aws_examples/s3/te-editorial-out-int`
+2. Edit `aws_examples/sns/parsed-judgment.json` to contain your tarfile name in `s3-folder-url` and consignment reference
+   in `consignment-reference`
+3. In `scripts/setup-localstack.sh`, change the line which begins `awslocal s3 cp aws_examples/s3/te-editorial-out-int/`
+   to contain your tarfile name, e.g. if your tarfile is called `XYZ-123.tar.gz`, this line should read
+   `awslocal s3 cp aws_examples/s3/te-editorial-out-int/XYZ-123.tar.gz s3://te-editorial-out-int`
+4. Run `make setup` and `make send-message` to ingest your tarfile
+
 ## Deployment
 
 Every change to the `main` branch is automatically deployed to the staging environment via GitHub actions.

--- a/scripts/setup-localstack.sh
+++ b/scripts/setup-localstack.sh
@@ -30,6 +30,10 @@ awslocal s3api create-bucket \
 awslocal s3api create-bucket \
   --bucket public-asset-bucket
 
-awslocal s3 cp aws_examples/s3/te-editorial-out-int/TDR-2022-DNWR.tar.gz s3://te-editorial-out-int
+if [ -n "$1" ]; then
+  awslocal s3 cp $1 s3://te-editorial-out-int
+else
+  awslocal s3 cp aws_examples/s3/te-editorial-out-int/TDR-2022-DNWR.tar.gz s3://te-editorial-out-int
+fi
 
 awslocal sqs create-queue --queue-name retry-queue


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Improve the way we test a tarfile locally. You can now pass a test tarfile as a parameter to the `make` commands, instead of editing the files in `aws_examples` to point to a different test tarfile.

This has been partially pulled from https://github.com/nationalarchives/ds-caselaw-ingester/pull/45