### PR TITLE
Email notifications should trigger on correct spelling of ROLLBAR_ENV, 'prod'

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -151,7 +151,7 @@ def store_file(file, folder, filename, s3_client: Session.client):
 
 
 def send_new_judgment_notification(uri: str, metadata: dict):
-    if os.getenv("ROLLBAR_ENV") == "production":
+    if os.getenv("ROLLBAR_ENV") == "prod":
         tdr_metadata = metadata["parameters"]["TDR"]
         notifications_client = NotificationsAPIClient(os.getenv("NOTIFY_API_KEY"))
         response = notifications_client.send_email_notification(
@@ -171,7 +171,7 @@ def send_new_judgment_notification(uri: str, metadata: dict):
 
 
 def send_updated_judgment_notification(uri: str, metadata: dict):
-    if os.getenv("ROLLBAR_ENV") == "production":
+    if os.getenv("ROLLBAR_ENV") == "prod":
         tdr_metadata = metadata["parameters"]["TDR"]
         notifications_client = NotificationsAPIClient(os.getenv("NOTIFY_API_KEY"))
         response = notifications_client.send_email_notification(

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -207,7 +207,7 @@ class LambdaTest(unittest.TestCase):
             "EDITORIAL_UI_BASE_URL": "http://editor.url/",
             "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
             "NOTIFY_NEW_JUDGMENT_TEMPLATE_ID": "template-id",
-            "ROLLBAR_ENV": "production",
+            "ROLLBAR_ENV": "prod",
         },
         clear=True,
     )
@@ -261,7 +261,7 @@ class LambdaTest(unittest.TestCase):
             "EDITORIAL_UI_BASE_URL": "http://editor.url/",
             "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
             "NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID": "template-id",
-            "ROLLBAR_ENV": "production",
+            "ROLLBAR_ENV": "prod",
         },
         clear=True,
     )


### PR DESCRIPTION
Slack discussion: https://dxw.slack.com/archives/C02TP2L2Z0F/p1671100904231339

After a deploy it was discovered that notification emails weren't being sent; the code that suppressed emails on staging had previously only been deployed to staging, and checked the `ROLLBAR_ENV` was set to `production`, rather than the value of `prod` that's actually used, so it also suppressed production emails once fully rolled out.