### PR TITLE
Better rollbar errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]


### PR DESCRIPTION
Tied to https://trello.com/c/kbTJqxXM/423-tdr-2023-lv6-editors-did-not-receive-email-notification-judgment-not-in-eui-but-tre-sent-slack-notification

1) Explicitly raise errors rather than potentially silencing them (and bare exceptions are bad)
2) Raise error containing AWS message if a HTTP Error code is sent
3) Put data into a named local variable so rollbar can see it
4) Fiddle with isort to get it working again.