### PR TITLE
Update docker configuration for localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 4566:4566
     volumes:
-      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
 
 networks:


### PR DESCRIPTION
Suppress the following error:

```
localstack_1  | ERROR
localstack_1  | ============================================================================
localstack_1  |   It seems you are mounting the LocalStack volume into /tmp/localstack.
localstack_1  |   This will break the LocalStack container! Please update your volume mount
localstack_1  |   destination to /var/lib/localstack.
localstack_1  |   You can suppress this error by setting LEGACY_DIRECTORIES=1.
localstack_1  |
localstack_1  |   See: https://github.com/localstack/localstack/issues/6398
localstack_1  | ============================================================================
localstack_1  |
ds-caselaw-ingester_localstack_1 exited with code 1
```

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
