### PR TITLE
Distinguish documents at ingestion

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -307,9 +307,9 @@ def update_judgment_xml(uri, xml) -> bool:
         return False
 
 
-def insert_judgment_xml(uri, xml) -> bool:
+def insert_document_xml(uri, xml) -> bool:
     try:
-        api_client.insert_judgment_xml(uri, xml)
+        api_client.insert_document_xml(uri, xml)
         return True
     except MarklogicCommunicationError:
         return False
@@ -394,7 +394,7 @@ def handler(event, context):
     xml = get_best_xml(uri, tar, xml_file_name, consignment_reference)
 
     updated = update_judgment_xml(uri, xml)
-    inserted = False if updated else insert_judgment_xml(uri, xml)
+    inserted = False if updated else insert_document_xml(uri, xml)
 
     if updated:
         # Notify editors that a document has been updated

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -588,18 +588,18 @@ class TestLambda:
         result = lambda_function.update_judgment_xml("a/fake/uri", xml)
         assert result is False
 
-    def test_insert_judgment_xml_success(self):
+    def test_insert_document_xml_success(self):
         xml = ET.XML("<xml>Here's some xml</xml>")
-        api_client.insert_judgment_xml = MagicMock(return_value=True)
-        result = lambda_function.insert_judgment_xml("a/fake/uri", xml)
+        api_client.insert_document_xml = MagicMock(return_value=True)
+        result = lambda_function.insert_document_xml("a/fake/uri", xml)
         assert result is True
 
-    def test_insert_judgment_xml_failure(self):
+    def test_insert_document_xml_failure(self):
         xml = ET.XML("<xml>Here's some xml</xml>")
-        api_client.insert_judgment_xml = MagicMock(
+        api_client.insert_document_xml = MagicMock(
             side_effect=MarklogicCommunicationError("error")
         )
-        result = lambda_function.insert_judgment_xml("a/fake/uri", xml)
+        result = lambda_function.insert_document_xml("a/fake/uri", xml)
         assert result is False
 
     def test_get_best_xml_with_valid_xml_file(self):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
-django-environ==0.8.1
-ds-caselaw-marklogic-api-client~=4.5.2
-requests-toolbelt==0.9.1
-urllib3==1.26.9
+django-environ~=0.10
+ds-caselaw-marklogic-api-client~=10.0
+requests-toolbelt~=1.0
+urllib3~=1.26
 boto3
 rollbar
-notifications-python-client~=6.3
+notifications-python-client~=8.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
-awscli==1.22.80
-awscli-local==0.20
+awscli
+awscli-local
 
 pytest==7.1.1  # https://github.com/pytest-dev/pytest
 callee==0.3.1


### PR DESCRIPTION
## Changes in this PR:
Distinguish documents at ingestion

Dependent on https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/236 being merged and then a version 10.0.0 of the api client being released.

## Trello card / Rollbar error (etc)
https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously