### PR TITLE
Upgraded ds-caselaw-marklogic-api-client to 10.0.1 so that insert_doc…

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client~=10.0
+ds-caselaw-marklogic-api-client==10.0.1
 requests-toolbelt~=1.0
 urllib3~=1.26
 boto3


### PR DESCRIPTION
## Changes in this PR:
Upgraded `ds-caselaw-marklogic-api-client` to 10.0.1 so that `insert_document_xml` uses `press-summary`, not `press_summary`

Note:

I needed to make the staging (and production) ingester point to the new version of api client, 10.0.1. However, the requirements.txt is just pinned to the minor version 10.0 and the patch version is free and I have not had to make any actual changes to the ingester repo (the bug was solely in the apiclient repo). Therefore I needed to either:
- make a dummy commit
- make a commit where I specify the version 10.0.1 for the deployment process to be deployed to staging
- create the lambda image manually and push it to aws (but Im not entirely sure I have the ability to do that)

I ended up thinking that it makes sense to be specific with dependencies that are our own (such as this)

## Trello card / Rollbar error (etc)
https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously