### PR TITLE
Use newer format for external networks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,5 @@ services:
 
 networks:
   default:
-    external:
-      name: caselaw
+    name: caselaw
+    external: true


### PR DESCRIPTION
Suppresses 
WARN[0000] network default: network.external.name is deprecated. Please set network.name with external: true 
error.