### PR TITLE
Debug: save file first

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -427,6 +427,11 @@ def handler(event, context):
     tar = tarfile.open(filename, mode="r")
     metadata = extract_metadata(tar, consignment_reference)
 
+    if not message.is_v1():
+        # this is just for debug purposes, it should be safely removable
+        uri = extract_uri(metadata, consignment_reference)
+        store_file(open(filename, mode="rb"), "v2-debug", "debug.tar.gz", s3_client)
+
     # Extract and parse the judgment XML
     xml_file_name = metadata["parameters"]["TRE"]["payload"]["xml"]
     uri = extract_uri(metadata, consignment_reference)


### PR DESCRIPTION
I'd failed to realise that the previous PR didn't solve the problem because the error was a little earlier -- we now deliberately save the tar gz so we can take a look inside. We should remove this code when we're done. 