### PR TITLE
Avoid collisions with metadata.json when looking for TDR-2023-4DR-metajson.json

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -455,7 +455,10 @@ def handler(event, context):
         )
 
     # Store metadata
-    store_metadata(uri, metadata)
+
+    has_TDR_data = "TDR" in metadata["parameters"].keys()
+    if has_TDR_data:
+        store_metadata(uri, metadata)
 
     # Copy original tarfile
     store_file(open(filename, mode="rb"), uri, os.path.basename(filename), s3_client)

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -156,7 +156,7 @@ def extract_metadata(tar: tarfile, consignment_reference: str):
     te_metadata_file = None
     decoder = json.decoder.JSONDecoder()
     for member in tar.getmembers():
-        if "metadata.json" in member.name:
+        if "-metadata.json" in member.name:
             te_metadata_file = tar.extractfile(member)
 
     if te_metadata_file is None:

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -143,11 +143,6 @@ class TestLambda:
         "../aws_examples/s3/te-editorial-out-int/TDR-2022-DNWR.tar.gz",
     )
 
-    EDGE_TARBALL_PATH = os.path.join(
-        os.path.dirname(__file__),
-        "../aws_examples/s3/te-editorial-out-int/ewca_civ_2021_1881.tar.gz",
-    )
-
     TARBALL_MISSING_METADATA_PATH = os.path.join(
         os.path.dirname(__file__),
         "../aws_examples/s3/te-editorial-out-int/TAR-MISSING-METADATA.tar.gz",
@@ -168,26 +163,7 @@ class TestLambda:
         xml = ET.XML(result.read())
         assert xml.tag == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
 
-    def test_extract_xml_file_success_edge(self):
-        filename = "judgment.xml"
-        tar = tarfile.open(
-            self.EDGE_TARBALL_PATH,
-            mode="r",
-        )
-        result = lambda_function.extract_xml_file(tar, filename)
-        # XML document may not be valid in an "edge" tarball, so just check the file is there
-        assert result is not None
-
     def test_extract_xml_file_not_found_tdr(self):
-        filename = "unknown.xml"
-        tar = tarfile.open(
-            self.TDR_TARBALL_PATH,
-            mode="r",
-        )
-        result = lambda_function.extract_xml_file(tar, filename)
-        assert result is None
-
-    def test_extract_xml_file_not_found_edge(self):
         filename = "unknown.xml"
         tar = tarfile.open(
             self.TDR_TARBALL_PATH,
@@ -209,15 +185,6 @@ class TestLambda:
         consignment_reference = "TDR-2022-DNWR"
         tar = tarfile.open(
             self.TDR_TARBALL_PATH,
-            mode="r",
-        )
-        result = lambda_function.extract_metadata(tar, consignment_reference)
-        assert result["parameters"]["TRE"]["payload"] is not None
-
-    def test_extract_metadata_success_edge(self):
-        consignment_reference = "name_of_tarfile"
-        tar = tarfile.open(
-            self.EDGE_TARBALL_PATH,
             mode="r",
         )
         result = lambda_function.extract_metadata(tar, consignment_reference)


### PR DESCRIPTION
We search for `-metadata.json` to avoid the spurious `metadata.json`