### PR TITLE
Upgrade to apiclient 14.0.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,10 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client==10.0.1
+ds-caselaw-marklogic-api-client==14.0.2
 requests-toolbelt~=1.0
 urllib3~=1.26
 boto3
 rollbar
 notifications-python-client~=8.0
+
+mypy-boto3-s3
+mypy-boto3-sns


### PR DESCRIPTION
## Changes in this PR:
- Upgrade to apiclient 14.0.2 and added mypy-botp dependencies since it seems apiclient now depdends on them but they must be extras or something and so we need to install them here otherwise we error for example with:
```
ds-caselaw-ingester/lambda_function.py:15: in <module>
    from caselawclient.Client import (
venv/lib/python3.11/site-packages/caselawclient/Client.py:18: in <module>
    from caselawclient.models.documents import (
venv/lib/python3.11/site-packages/caselawclient/models/documents.py:13: in <module>
    from .utilities.aws import (
venv/lib/python3.11/site-packages/caselawclient/models/utilities/aws.py:8: in <module>
    from mypy_boto3_s3.client import S3Client
E   ModuleNotFoundError: No module named 'mypy_boto3_s3'
```

## Trello card / Rollbar error (etc)
https://trello.com/c/p9LRm2Wi/1210-use-apiclient-13-save-versioning-behaviour-in-editor-ingester-enrichment