### PR TITLE
⚠️ Set user agent and build own API client object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist
 .DS_Store
 .aws-sam
 */__pycache__
+
+tmp
+volume

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -13,13 +13,26 @@ import urllib3
 from boto3.session import Session
 from botocore.exceptions import NoCredentialsError
 from caselawclient.Client import (
+    DEFAULT_USER_AGENT,
+    MarklogicApiClient,
     MarklogicCommunicationError,
     MarklogicResourceNotFoundError,
-    api_client,
 )
+from dotenv import load_dotenv
 from notifications_python_client.notifications import NotificationsAPIClient
 
+load_dotenv()
+
+
 rollbar.init(os.getenv("ROLLBAR_TOKEN"), environment=os.getenv("ROLLBAR_ENV"))
+
+api_client = MarklogicApiClient(
+    host=os.getenv("MARKLOGIC_HOST", default=None),
+    username=os.getenv("MARKLOGIC_USER", default=None),
+    password=os.getenv("MARKLOGIC_PASSWORD", default=None),
+    use_https=os.getenv("MARKLOGIC_USE_HTTPS", default=False),
+    user_agent=f"ds-caselaw-ingester/unknown {DEFAULT_USER_AGENT}",
+)
 
 
 class Message(object):

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -269,7 +269,7 @@ class TestLambda:
         session.upload_fileobj = MagicMock()
         lambda_function.store_file(None, "folder", "filename.ext", session)
         mock_print.assert_called_with("Upload Successful folder/filename.ext")
-        session.upload_fileobj.assert_called_with(None, None, "folder/filename.ext")
+        session.upload_fileobj.assert_called_with(None, ANY, "folder/filename.ext")
 
     @patch("builtins.print")
     def test_store_file_file_not_found(self, mock_print):
@@ -277,7 +277,7 @@ class TestLambda:
         session.upload_fileobj = MagicMock(side_effect=FileNotFoundError)
         lambda_function.store_file(None, "folder", "filename.ext", session)
         mock_print.assert_called_with("The file folder/filename.ext was not found")
-        session.upload_fileobj.assert_called_with(None, None, "folder/filename.ext")
+        session.upload_fileobj.assert_called_with(None, ANY, "folder/filename.ext")
 
     @patch("builtins.print")
     def test_store_file_file_no_credentials(self, mock_print):
@@ -285,7 +285,7 @@ class TestLambda:
         session.upload_fileobj = MagicMock(side_effect=NoCredentialsError)
         lambda_function.store_file(None, "folder", "filename.ext", session)
         mock_print.assert_called_with("Credentials not available")
-        session.upload_fileobj.assert_called_with(None, None, "folder/filename.ext")
+        session.upload_fileobj.assert_called_with(None, ANY, "folder/filename.ext")
 
     @patch.dict(
         os.environ,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client==14.0.2
+ds-caselaw-marklogic-api-client==14.1.0
 requests-toolbelt~=1.0
 urllib3~=1.26
 boto3
@@ -8,3 +8,4 @@ notifications-python-client~=8.0
 
 mypy-boto3-s3
 mypy-boto3-sns
+python-dotenv

--- a/scripts/test
+++ b/scripts/test
@@ -1,1 +1,1 @@
-MARKLOGIC_HOST= MARKLOGIC_USER= MARKLOGIC_PASSWORD= python -m pytest ds-caselaw-ingester/tests.py $*
+python -m pytest ds-caselaw-ingester/tests.py $*


### PR DESCRIPTION
Note: this changes how we handle environment variables; take care that this works correctly in staging before deploying to live.