### PR TITLE
Filter out non-courtdoc messages from eventbus less aggressively

### DIFF
--- a/aws_examples/sns/parsed-judgment-v2.json
+++ b/aws_examples/sns/parsed-judgment-v2.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "messageType": "uk.gov.nationalarchives.tre.messages.courtdocumentpackage.available.CourtDocumentPackageAvailable",
+    "messageType": "uk.gov.nationalarchives.da.messages.courtdocumentpackage.available.CourtDocumentPackageAvailable",
     "timestamp": "2023-06-28T09:09:25.670688Z",
     "function": "staging-tre-court-document-pack-lambda",
     "producer": "TRE",

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -26,7 +26,7 @@ v2_message_raw = """
     {
         "properties": {
             "messageType":
-                "uk.gov.nationalarchives.tre.messages.judgmentpackage.available.JudgmentPackageAvailable",
+                "uk.gov.nationalarchives.da.messages.courtdocumentpackage.available.CourtDocumentPackageAvailable",
             "timestamp": "2023-05-15T09:14:53.791409Z",
             "function": "staging-tre-judgment-packer-lambda",
             "producer": "TRE",


### PR DESCRIPTION


## Changes in this PR:
- Filter out non-courtdoc messages from eventbus

https://linear.app/tna/issue/FCL-144/ingester-recieves-messages-from-eventbus
