### PR TITLE
Allow `MarklogicCommunicationError`s to crash ingester

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -15,7 +15,6 @@ from botocore.exceptions import NoCredentialsError
 from caselawclient.Client import (
     DEFAULT_USER_AGENT,
     MarklogicApiClient,
-    MarklogicCommunicationError,
     MarklogicResourceNotFoundError,
 )
 from dotenv import load_dotenv
@@ -380,16 +379,13 @@ def update_judgment_xml(uri, xml) -> bool:
         api_client.get_judgment_xml(uri, show_unpublished=True)
         api_client.save_judgment_xml(uri, xml)
         return True
-    except (MarklogicResourceNotFoundError, MarklogicCommunicationError):
+    except MarklogicResourceNotFoundError:
         return False
 
 
 def insert_document_xml(uri, xml) -> bool:
-    try:
-        api_client.insert_document_xml(uri, xml)
-        return True
-    except MarklogicCommunicationError:
-        return False
+    api_client.insert_document_xml(uri, xml)
+    return True
 
 
 def get_best_xml(uri, tar, xml_file_name, consignment_reference):

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -670,8 +670,8 @@ class TestLambda:
         api_client.save_judgment_xml = MagicMock(
             side_effect=MarklogicCommunicationError("error")
         )
-        result = lambda_function.update_judgment_xml("a/fake/uri", xml)
-        assert result is False
+        with pytest.raises(MarklogicCommunicationError):
+            lambda_function.update_judgment_xml("a/fake/uri", xml)
 
     @patch("lambda_function.api_client")
     def test_insert_document_xml_success(self, api_client):
@@ -686,8 +686,8 @@ class TestLambda:
         api_client.insert_document_xml = MagicMock(
             side_effect=MarklogicCommunicationError("error")
         )
-        result = lambda_function.insert_document_xml("a/fake/uri", xml)
-        assert result is False
+        with pytest.raises(MarklogicCommunicationError):
+            lambda_function.insert_document_xml("a/fake/uri", xml)
 
     def test_get_best_xml_with_valid_xml_file(self):
         filename = "TDR-2022-DNWR.xml"


### PR DESCRIPTION
They are catch-all exceptions for unexpected behaviour -- it's OK to stop
and report the situation rather than plow on pretending everything's fine.