### PR TITLE
Tell Renovate where to find our dependency files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>nationalarchives/ds-find-caselaw-docs"]
+  "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
+  "pip_requirements": {
+    "fileMatch": ["requirements/*.txt"]
+  }
 }


### PR DESCRIPTION
Our dependency files for pip are in a strange place which means they're not automatically found by Renovate. This fixes the problem by explicitly providing their locations.