### PR TITLE
Define environment variables and timeout in code

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - name: Run latest-tag
@@ -19,4 +20,19 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_PRODUCTION_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
       - run: sam build --use-container -m requirements/base.txt
-      - run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name ds-caselaw-ingester --s3-bucket tna-caselaw-ingester-deploy --capabilities CAPABILITY_IAM --region eu-west-2
+      - run: >
+          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name ds-caselaw-ingester --s3-bucket tna-caselaw-ingester-deploy --capabilities CAPABILITY_IAM --region eu-west-2 --parameter-overrides
+          AwsBucketName=${{ vars.AWS_BUCKET_NAME  }}
+          EditorialUiBaseUrl=${{ vars.EDITORIAL_UI_BASE_URL  }}
+          MarklogicHost=${{ secrets.MARKLOGIC_HOST }}
+          MarklogicPassword=${{ secrets.MARKLOGIC_PASSWORD }}
+          MarklogicUser=${{ secrets.MARKLOGIC_USER }}
+          MaxRetries=${{ vars.MAX_RETRIES  }}
+          NotifyApiKey=${{ secrets.NOTIFY_API_KEY }}
+          NotifyEditorialAddress=${{ vars.NOTIFY_EDITORIAL_ADDRESS  }}
+          NotifyNewJudgmentTemplateId=${{ vars.NOTIFY_NEW_JUDGMENT_TEMPLATE_ID  }}
+          NotifyUpdatedJudgmentTemplateId=${{ vars.NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID  }}
+          PublicAssetBucket=${{ vars.PUBLIC_ASSET_BUCKET  }}
+          RollbarEnv=${{ vars.ROLLBAR_ENV  }}
+          RollbarToken=${{ secrets.ROLLBAR_TOKEN }}
+          SqsQueueUrl=${{ vars.SQS_QUEUE_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,19 +19,19 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
       - run: sam build --use-container -m requirements/base.txt
-      - run:
-          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name ds-caselaw-ingester --s3-bucket ingester-test-2 --capabilities CAPABILITY_IAM --region eu-west-2 --parameter-overrides \
-          ParameterKey=AWS_BUCKET_NAME,ParameterValue=${{ vars.AWS_BUCKET_NAME }} \
-          ParameterKey=EDITORIAL_UI_BASE_URL,ParameterValue=${{ vars.EDITORIAL_UI_BASE_URL }} \
-          ParameterKey=MARKLOGIC_HOST,ParameterValue=${{ secrets.MARKLOGIC_HOST }} \
-          ParameterKey=MARKLOGIC_PASSWORD,ParameterValue=${{ secrets.MARKLOGIC_PASSWORD }} \
-          ParameterKey=MARKLOGIC_USER,ParameterValue=${{ secrets.MARKLOGIC_USER }} \
-          ParameterKey=MAX_RETRIES,ParameterValue=${{ vars.MAX_RETRIES }} \
-          ParameterKey=NOTIFY_API_KEY,ParameterValue=${{ secrets.NOTIFY_API_KEY }} \
-          ParameterKey=NOTIFY_EDITORIAL_ADDRESS,ParameterValue=${{ vars.NOTIFY_EDITORIAL_ADDRESS }} \
-          ParameterKey=NOTIFY_NEW_JUDGMENT_TEMPLATE_ID,ParameterValue=${{ vars.NOTIFY_NEW_JUDGMENT_TEMPLATE_ID }} \
-          ParameterKey=NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID,ParameterValue=${{ vars.NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID }} \
-          ParameterKey=PUBLIC_ASSET_BUCKET,ParameterValue=${{ vars.PUBLIC_ASSET_BUCKET }} \
-          ParameterKey=ROLLBAR_ENV,ParameterValue=${{ vars.ROLLBAR_ENV }} \
-          ParameterKey=ROLLBAR_TOKEN,ParameterValue=${{ secrets.ROLLBAR_TOKEN }} \
-          ParameterKey=SQS_QUEUE_URL,ParameterValue=${{ vars.SQS_QUEUE_URL }}
+      - run: >
+          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name ds-caselaw-ingester --s3-bucket ingester-test-2 --capabilities CAPABILITY_IAM --region eu-west-2 --parameter-overrides
+          AwsBucketName=${{ vars.AWS_BUCKET_NAME  }}
+          EditorialUiBaseUrl=${{ vars.EDITORIAL_UI_BASE_URL  }}
+          MarklogicHost=${{ secrets.MARKLOGIC_HOST }}
+          MarklogicPassword=${{ secrets.MARKLOGIC_PASSWORD }}
+          MarklogicUser=${{ secrets.MARKLOGIC_USER }}
+          MaxRetries=${{ vars.MAX_RETRIES  }}
+          NotifyApiKey=${{ secrets.NOTIFY_API_KEY }}
+          NotifyEditorialAddress=${{ vars.NOTIFY_EDITORIAL_ADDRESS  }}
+          NotifyNewJudgmentTemplateId=${{ vars.NOTIFY_NEW_JUDGMENT_TEMPLATE_ID  }}
+          NotifyUpdatedJudgmentTemplateId=${{ vars.NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID  }}
+          PublicAssetBucket=${{ vars.PUBLIC_ASSET_BUCKET  }}
+          RollbarEnv=${{ vars.ROLLBAR_ENV  }}
+          RollbarToken=${{ secrets.ROLLBAR_TOKEN }}
+          SqsQueueUrl=${{ vars.SQS_QUEUE_URL }}

--- a/template.yml
+++ b/template.yml
@@ -11,46 +11,46 @@ Globals:
     Timeout: 3
 
 Parameters:
-  AWS_BUCKET_NAME:
+  AwsBucketName:
     Description: "AWS_BUCKET_NAME"
     Type: "String"
-  EDITORIAL_UI_BASE_URL:
+  EditorialUiBaseUrl:
     Description: "EDITORIAL_UI_BASE_URL"
     Type: "String"
-  MARKLOGIC_HOST:
+  MarklogicHost:
     Description: "MARKLOGIC_HOST"
     Type: "String"
-  MARKLOGIC_PASSWORD:
+  MarklogicPassword:
     Description: "MARKLOGIC_PASSWORD"
     Type: "String"
-  MARKLOGIC_USER:
+  MarklogicUser:
     Description: "MARKLOGIC_USER"
     Type: "String"
-  MAX_RETRIES:
+  MaxRetries:
     Description: "MAX_RETRIES"
     Type: "String"
-  NOTIFY_API_KEY:
+  NotifyApiKey:
     Description: "NOTIFY_API_KEY"
     Type: "String"
-  NOTIFY_EDITORIAL_ADDRESS:
+  NotifyEditorialAddress:
     Description: "NOTIFY_EDITORIAL_ADDRESS"
     Type: "String"
-  NOTIFY_NEW_JUDGMENT_TEMPLATE_ID:
+  NotifyNewJudgmentTemplateId:
     Description: "NOTIFY_NEW_JUDGMENT_TEMPLATE_ID"
     Type: "String"
-  NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID:
+  NotifyUpdatedJudgmentTemplateId:
     Description: "NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID"
     Type: "String"
-  PUBLIC_ASSET_BUCKET:
+  PublicAssetBucket:
     Description: "PUBLIC_ASSET_BUCKET"
     Type: "String"
-  ROLLBAR_ENV:
+  RollbarEnv:
     Description: "ROLLBAR_ENV"
     Type: "String"
-  ROLLBAR_TOKEN:
+  RollbarToken:
     Description: "ROLLBAR_TOKEN"
     Type: "String"
-  SQS_QUEUE_URL:
+  SqsQueueUrl:
     Description: "SQS_QUEUE_URL"
     Type: "String"
 
@@ -65,20 +65,20 @@ Resources:
         - x86_64
       Environment:
         Variables:
-          AWS_BUCKET_NAME: !Ref AWS_BUCKET_NAME
-          EDITORIAL_UI_BASE_URL: !Ref EDITORIAL_UI_BASE_URL
-          MARKLOGIC_HOST: !Ref MARKLOGIC_HOST
-          MARKLOGIC_PASSWORD: !Ref MARKLOGIC_PASSWORD
-          MARKLOGIC_USER: !Ref MARKLOGIC_USER
-          MAX_RETRIES: !Ref MAX_RETRIES
-          NOTIFY_API_KEY: !Ref NOTIFY_API_KEY
-          NOTIFY_EDITORIAL_ADDRESS: !Ref NOTIFY_EDITORIAL_ADDRESS
-          NOTIFY_NEW_JUDGMENT_TEMPLATE_ID: !Ref NOTIFY_NEW_JUDGMENT_TEMPLATE_ID
-          NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID: !Ref NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID
-          PUBLIC_ASSET_BUCKET: !Ref PUBLIC_ASSET_BUCKET
-          ROLLBAR_ENV: !Ref ROLLBAR_ENV
-          ROLLBAR_TOKEN: !Ref ROLLBAR_TOKEN
-          SQS_QUEUE_URL: !Ref SQS_QUEUE_URL
+          AWS_BUCKET_NAME: !Ref AwsBucketName
+          EDITORIAL_UI_BASE_URL: !Ref EditorialUiBaseUrl
+          MARKLOGIC_HOST: !Ref MarklogicHost
+          MARKLOGIC_PASSWORD: !Ref MarklogicPassword
+          MARKLOGIC_USER: !Ref MarklogicUser
+          MAX_RETRIES: !Ref MaxRetries
+          NOTIFY_API_KEY: !Ref NotifyApiKey
+          NOTIFY_EDITORIAL_ADDRESS: !Ref NotifyEditorialAddress
+          NOTIFY_NEW_JUDGMENT_TEMPLATE_ID: !Ref NotifyNewJudgmentTemplateId
+          NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID: !Ref NotifyUpdatedJudgmentTemplateId
+          PUBLIC_ASSET_BUCKET: !Ref PublicAssetBucket
+          ROLLBAR_ENV: !Ref RollbarEnv
+          ROLLBAR_TOKEN: !Ref RollbarToken
+          SQS_QUEUE_URL: !Ref SqsQueueUrl
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function

--- a/template.yml
+++ b/template.yml
@@ -63,6 +63,7 @@ Resources:
       Runtime: python3.11
       Architectures:
         - x86_64
+      Timeout: 420
       Environment:
         Variables:
           AWS_BUCKET_NAME: !Ref AwsBucketName


### PR DESCRIPTION
Previously we didn't define any environment variables at deploy time; instead we set them manually. A configuration change when we moved from Python 3.9 to 3.11 caused SAM to redefine the infrastructure, and this in turn caused a all existing environment variables to be wiped, bringing down the staging ingester.

This PR moves to defining the environment variables in the `template.yml` file which is used by SAM. The exact values are passed in at deploy time by GitHub Actions as part of configuring the infrastructure.

Variables are stored in GitHub environments.