### PR TITLE
Fix incorrect VPC config indentation

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -92,13 +92,13 @@ Resources:
           ROLLBAR_ENV: !Ref RollbarEnv
           ROLLBAR_TOKEN: !Ref RollbarToken
           SQS_QUEUE_URL: !Ref SqsQueueUrl
-    VpcConfig:
-      SubnetIds:
-        - !Ref VpcSubnetId0
-        - !Ref VpcSubnetId1
-        - !Ref VpcSubnetId2
-      SecurityGroupIds:
-        - !Ref VpcSecurityGroupId
+      VpcConfig:
+        SubnetIds:
+          - !Ref VpcSubnetId0
+          - !Ref VpcSubnetId1
+          - !Ref VpcSubnetId2
+        SecurityGroupIds:
+          - !Ref VpcSecurityGroupId
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function


### PR DESCRIPTION
The configuration should be within `Properties` so it's visible to CloudFormation, but instead of raising an error at this incorrect configuration SAM silently fails.