### PR TITLE
Do not set ACL because ACLs are deprecated

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -400,7 +400,7 @@ def update_published_documents(uri, s3_client):
 
         if "parser.log" not in key and not str(key).endswith(".tar.gz"):
             source = {"Bucket": private_bucket, "Key": key}
-            extra_args = {"ACL": "public-read"}
+            extra_args = {}
             s3_client.copy(source, public_bucket, key, extra_args)
 
 

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -633,13 +633,13 @@ class TestLambda:
                 {"Bucket": "private-bucket", "Key": "file1.ext"},
                 "public-bucket",
                 "file1.ext",
-                {"ACL": "public-read"},
+                {},
             ),
             call(
                 {"Bucket": "private-bucket", "Key": "file2.ext"},
                 "public-bucket",
                 "file2.ext",
-                {"ACL": "public-read"},
+                {},
             ),
         ]
         lambda_function.update_published_documents("uri", s3_client)


### PR DESCRIPTION
We are having challenges where the copy is failing, we believe because it is attempting to set a public-read ACL but we have set the flags on the bucket to prohibit public access.
