### PR TITLE
Explicitly make sure we set_published(True), not the implicit False

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -530,7 +530,7 @@ def handler(event, context):
     force_publish = Metadata(metadata).force_publish
     if force_publish is True:
         print(f"auto_publishing {consignment_reference} at {uri}")
-        api_client.set_published(uri)
+        api_client.set_published(uri, True)
 
     if api_client.get_published(uri) or force_publish:
         update_published_documents(uri, s3_client)

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -187,7 +187,7 @@ class TestHandler:
         assert "Upload Successful" in log
         assert "Ingestion complete" in log
         assert "auto_publish" in log
-        apiclient.set_published.assert_called_with("failures/TDR-2020-FAR")
+        apiclient.set_published.assert_called_with("failures/TDR-2020-FAR", True)
         notify_new.assert_not_called()
         notify_updated.assert_not_called()
         annotation.assert_called_with(


### PR DESCRIPTION
`set_published()` defaults to False. We want it to be True.

See also https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/482 to disarm this footgun.