### PR TITLE
Support tar.gz that have no docx and have nilsy docx filename in the metadata

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -510,13 +510,15 @@ def process_message(message):
 
     # Store docx and rename
     docx_filename = extract_docx_filename(metadata, consignment_reference)
-    copy_file(
-        tar,
-        f"{consignment_reference}/{docx_filename}",
-        f'{uri.replace("/", "_")}.docx',
-        uri,
-        s3_client,
-    )
+    # The docx_filename is None for files which have been reparsed.
+    if docx_filename is None:
+        copy_file(
+            tar,
+            f"{consignment_reference}/{docx_filename}",
+            f'{uri.replace("/", "_")}.docx',
+            uri,
+            s3_client,
+        )
 
     # Store parser log
     try:

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -267,6 +267,11 @@ class TestLambda:
             == "judgment.docx"
         )
 
+    def test_extract_docx_filename_no_docx_provided(self):
+        """Reparsed documents do not have a docx file and have the metadata set to None"""
+        metadata = {"parameters": {"TRE": {"payload": {"filename": None}}}}
+        assert lambda_function.extract_docx_filename(metadata, "anything") is None
+
     def test_extract_docx_filename_failure(self):
         metadata = {"parameters": {"TRE": {"payload": {}}}}
         with pytest.raises(lambda_function.DocxFilenameNotFoundException):


### PR DESCRIPTION
Documents that are reparsed do not contain a docx file; a slight departure from previous expectations that every tar.gz file must have a docx file. It's possible that we could check whether we're expecting a tar.gz file based on the message type, but that feels like overcomplicating things.