### PR TITLE
Don't change the local filename, only the stored filename

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -524,9 +524,9 @@ def process_message(message):
         filename if docx_filename else modify_filename(filename, "_nodocx")
     )
     store_file(
-        open(modified_targz_filename, mode="rb"),
+        open(filename, mode="rb"),
         uri,
-        os.path.basename(filename),
+        os.path.basename(modified_targz_filename),
         s3_client,
     )
     print(f"saved tar.gz as {modified_targz_filename!r}")


### PR DESCRIPTION
There was a bug in the no_docx code -- we changed the local filename we tried to read from, not the remote filename in S3.