### PR TITLE
Fix incorrect way of getting whether the document is published

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -17,7 +17,6 @@ from caselawclient.Client import (
 )
 from caselawclient.client_helpers import VersionAnnotation, VersionType
 from caselawclient.errors import DocumentNotFoundError
-from caselawclient.models.documents import Document
 from dotenv import load_dotenv
 from notifications_python_client.notifications import NotificationsAPIClient
 
@@ -496,7 +495,7 @@ def process_message(message):
     is_akoma = xml.tag == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
 
     try:
-        target_published = Document(uri, api_client).get_published()
+        target_published = api_client.get_published(uri)
     except DocumentNotFoundError:  # the target does not exist
         target_published = False
 

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -93,10 +93,8 @@ class TestHandler:
     @patch("lambda_function.send_new_judgment_notification")
     @patch("lambda_function.VersionAnnotation")
     @patch("lambda_function.modify_filename")
-    @patch("lambda_function.Document")
     def test_handler_messages_v2(
         self,
-        document,
         modify_filename,
         annotation,
         notify_new,
@@ -106,7 +104,7 @@ class TestHandler:
         capsys,
     ):
 
-        document.return_value.get_published.return_value = False
+        apiclient.return_value.get_published.return_value = False
         boto_session.return_value.client.return_value.download_file = (
             create_fake_tdr_file
         )
@@ -140,10 +138,8 @@ class TestHandler:
     @patch("lambda_function.send_updated_judgment_notification")
     @patch("lambda_function.VersionAnnotation")
     @patch("lambda_function.modify_filename")
-    @patch("lambda_function.Document")
     def test_handler_messages_s3(
         self,
-        document,
         modify_filename,
         annotation,
         notify_new,
@@ -156,7 +152,7 @@ class TestHandler:
         boto_session.return_value.client.return_value.download_file = (
             create_fake_bulk_file
         )
-        document.return_value.get_published.return_value = False
+        apiclient.return_value.get_published.return_value = False
 
         message = s3_message_raw
         event = {


### PR DESCRIPTION
Document.is_published() or api_client.get_published()

Don't merge this at all if we're happy with the changes in the other PR that refactors all of this -- that will fix the problem.