### PR TITLE
Upgrade localstack to 3.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   localstack:
-    image: localstack/localstack:2.3.2
+    image: localstack/localstack:3.5.0
     network_mode: bridge
     environment:
       SERVICES: lambda,sns,s3,sqs,iam


### PR DESCRIPTION
We were having issues with errors on pdf-converter where the v2 AWS API was trying to be used but was causing errors. Upgrading fixed them.

Something like:

localstack.aws.protocol.parser.ProtocolParserError: Operation detection failed. Missing Action in request for query-protocol service ServiceModel(sqs)

<!-- Amend as appropriate -->

## Changes in this PR:

## Jira card / Rollbar error (etc)

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
