### PR TITLE
[FCL-447] Fix workflow permissions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* The AWS OIDC requires the `id-token` permission