### PR TITLE
[FCL-447] Fix Staging workflow permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* The AWS OIDC (for the staging workflow) requires the `id-token` permission