### PR TITLE
Chaneg Production workflow permissions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   build-deploy:


### PR DESCRIPTION
* The production workflow creates a tag on the repository, which requires the `content: write` permission