### PR TITLE
Use save_identifiers on document not identifiers.save()

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -456,7 +456,7 @@ class Ingest:
 
         if ncn:
             doc.identifiers.add(NeutralCitationNumber(ncn))
-            doc.identifiers.save(doc)
+            doc.save_identifiers(doc)
             logger.info(f"Ingested document had NCN {ncn}")
         else:
             logger.info(f"Ingested document had NCN (NOT FOUND)")

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -215,7 +215,7 @@ class TestHandler:
         )
         assert annotation.call_count == 2
         assert doc.identifiers.add.call_args_list[0].args[0].value == "[2012] UKUT 82 (IAC)"
-        doc.identifiers.save.assert_called()
+        doc.save_identifiers.assert_called()
 
 
 class TestLambda:


### PR DESCRIPTION
We updated the api client to use document.save_identifiers() not document.identifiers.save() -- implement that change here.