### PR TITLE
Hotfix: Release with API client v29

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client==28.1.0
+ds-caselaw-marklogic-api-client==29.0.1
 requests-toolbelt~=1.0
 urllib3~=2.2
 boto3


### PR DESCRIPTION
Bump API client to v29 to get the hotfixes for missing identifier handling.

**This is not intended to be merged, it's here to support a hotfixed deploy.** When the proper v29 update with UUID-based URIs is merged this branch can be removed.