### PR TITLE
Enable more ruff checks to improve code quality

### DIFF
--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -47,7 +47,7 @@ api_client = MarklogicApiClient(
 )
 
 
-class Metadata(object):
+class Metadata:
     def __init__(self, metadata):
         self.metadata = metadata
         self.parameters = metadata.get("parameters", {})
@@ -61,7 +61,7 @@ class Metadata(object):
         return self.parameters.get("INGESTER_OPTIONS", {}).get("auto_publish", False)
 
 
-class Message(object):
+class Message:
     @classmethod
     def from_event(cls, event):
         decoder = json.decoder.JSONDecoder()

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -247,10 +247,10 @@ def get_consignment_reference(message):
 def extract_docx_filename(metadata: dict, consignment_reference: str) -> str:
     try:
         return metadata["parameters"]["TRE"]["payload"]["filename"]
-    except KeyError:
+    except KeyError as err:
         raise DocxFilenameNotFoundException(
             f"No .docx filename was found in metadata. Consignment Ref: {consignment_reference}, metadata: {metadata}"
-        )
+        ) from err
 
 
 def extract_lambda_versions(versions: list[dict[str, str]]) -> list[tuple[str, str]]:
@@ -292,8 +292,8 @@ def copy_file(tarfile, input_filename, output_filename, uri, s3_client: S3Client
     try:
         file = tarfile.extractfile(input_filename)
         store_file(file, uri, output_filename, s3_client)
-    except KeyError:
-        raise FileNotFoundException(f"File was not found: {input_filename}, files were {tarfile.getnames()} ")
+    except KeyError as err:
+        raise FileNotFoundException(f"File was not found: {input_filename}, files were {tarfile.getnames()} ") from err
 
 
 def create_parser_log_xml(tar):

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -249,7 +249,7 @@ def extract_docx_filename(metadata: dict, consignment_reference: str) -> str:
         return metadata["parameters"]["TRE"]["payload"]["filename"]
     except KeyError as err:
         raise DocxFilenameNotFoundException(
-            f"No .docx filename was found in metadata. Consignment Ref: {consignment_reference}, metadata: {metadata}"
+            f"No .docx filename was found in metadata. Consignment Ref: {consignment_reference}, metadata: {metadata}",
         ) from err
 
 
@@ -352,7 +352,7 @@ def get_best_xml(uri, tar, xml_file_name, consignment_reference):
         except ET.ParseError:
             print(
                 f"Invalid XML file for uri: {uri}, consignment reference: {consignment_reference}."
-                f" Falling back to parser.log contents."
+                f" Falling back to parser.log contents.",
             )
             contents = create_parser_log_xml(tar)
             return parse_xml(contents)
@@ -360,7 +360,7 @@ def get_best_xml(uri, tar, xml_file_name, consignment_reference):
         print(
             f"No XML file found in tarfile for uri: {uri}, filename: {xml_file_name},"
             f"consignment reference: {consignment_reference}."
-            f" Falling back to parser.log contents."
+            f" Falling back to parser.log contents.",
         )
         contents = create_parser_log_xml(tar)
         return parse_xml(contents)
@@ -612,7 +612,7 @@ class Ingest:
         self.inserted = False if self.updated else self.insert_document_xml()
         if not self.updated and not self.inserted:
             raise DocumentInsertionError(
-                f"Judgment {self.uri} failed to insert into Marklogic. Consignment Ref: {self.consignment_reference}"
+                f"Judgment {self.uri} failed to insert into Marklogic. Consignment Ref: {self.consignment_reference}",
             )
         self.set_document_identifiers()
 

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -61,8 +61,8 @@ s3_message = {
                     "key": "QX/e31b117f-ff09-49b6-a697-7952c7a67384/BULK-0.tar.gz",
                 },
             },
-        }
-    ]
+        },
+    ],
 }
 v2_message = json.loads(v2_message_raw)
 s3_message_raw = json.dumps(s3_message)
@@ -312,8 +312,8 @@ class TestLambda:
                     "Internal-Sender-Identifier": "TDR-2021-CF6L",
                     "Consignment-Completed-Datetime": "2021-12-16T14:54:06Z",
                     "Contact-Email": "someone@example.com",
-                }
-            }
+                },
+            },
         }
         v2_ingest.uri = "uri"
 
@@ -446,8 +446,8 @@ class TestLambda:
                     "Internal-Sender-Identifier": "TDR-2021-CF6L",
                     "Consignment-Completed-Datetime": "2021-12-16T14:54:06Z",
                     "Contact-Email": "someone@example.com",
-                }
-            }
+                },
+            },
         }
         expected_personalisation = {
             "url": "http://editor.url/detail?judgment_uri=uri",

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -799,8 +799,8 @@ class TestEmailLogic:
         bulk.assert_not_called()
 
     @patch("lambda_function.Metadata.force_publish", new_callable=PropertyMock)
-    def test_s3_ingest_no_email_if_publish(self, property, bulk, new, updated, s3_ingest):
-        property.return_value = True
+    def test_s3_ingest_no_email_if_publish(self, mock_property, bulk, new, updated, s3_ingest):
+        mock_property.return_value = True
         s3_ingest.send_email()
 
         updated.assert_not_called()
@@ -808,8 +808,8 @@ class TestEmailLogic:
         bulk.assert_not_called()
 
     @patch("lambda_function.Metadata.force_publish", new_callable=PropertyMock)
-    def test_s3_ingest_email_if_not_publish(self, property, bulk, new, updated, s3_ingest):
-        property.return_value = False
+    def test_s3_ingest_email_if_not_publish(self, mock_property, bulk, new, updated, s3_ingest):
+        mock_property.return_value = False
         s3_ingest.send_email()
 
         updated.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC" ]
-# extend-select = [ "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE" ]
+# extend-select = [ "S", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ", "T10" ]
-# extend-select = [ "S", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ", "T10", "DJ" ]
+# extend-select = [ "S", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP" ]
-# extend-select = [ "YTT", "ASYNC", "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT" ]
+# extend-select = [ "ASYNC", "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE" ]
-# extend-select = [ "S", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4" ]
+# extend-select = [ "S", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ", "T10", "DJ" ]
-# extend-select = [ "S", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ", "T10", "DJ", "EXE" ]
+# extend-select = [ "S", "EM", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B"]
-# extend-select = [ "Q", "C90", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
-#                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q"]
+# extend-select = ["C90", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+#                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90" ]
-# extend-select = [ "UP", "YTT", "ASYNC", "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP" ]
+# extend-select = [ "YTT", "ASYNC", "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT" ]
-# extend-select = [ "ASYNC", "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC" ]
+# extend-select = [ "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A" ]
-# extend-select = ["C90", "UP", "YTT", "ASYNC", "S", "BLE", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM" ]
+# extend-select = ["C90", "UP", "YTT", "ASYNC", "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM"]
-# extend-select = [ "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B"]
+# extend-select = [ "Q", "C90", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ" ]
-# extend-select = [ "S", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ", "T10" ]
+# extend-select = [ "S", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM" ]
-# extend-select = ["C90", "UP", "YTT", "ASYNC", "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90" ]
+# extend-select = [ "UP", "YTT", "ASYNC", "S", "BLE", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q"]
-# extend-select = ["C90", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A" ]
+# extend-select = ["C90", "UP", "YTT", "ASYNC", "S", "BLE", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4" ]
-# extend-select = [ "S", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ" ]
+# extend-select = [ "S", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]


### PR DESCRIPTION
Switch on some more ruff checks and make necessary fixes to improve overall code quality, and prevent future errors creeping in.