### PR TITLE
[FCL-644] Improve typing and code robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       MARKLOGIC_PASSWORD: ml-password
       MARKLOGIC_USE_HTTPS: 0
       AWS_BUCKET_NAME: judgments-original-versions
+      PUBLIC_ASSET_BUCKET: public-asset-bucket
     name: Run unit tests
     runs-on: ubuntu-24.04
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
           - types-python-dateutil
           - types-pytz
           - boto3-stubs[s3,sns]
-          - ds-caselaw-marklogic-api-client~=29.0.0
+          - ds-caselaw-marklogic-api-client~=31.1.0
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -319,7 +319,7 @@ def copy_file(
         raise FileNotFoundException(f"File was not found: {input_filename}, files were {tarfile.getnames()} ") from err
 
 
-def create_parser_log_xml(tar: tarfile.TarFile) -> str:
+def create_parser_log_xml(tar: tarfile.TarFile) -> bytes:
     parser_log_value = "<error>parser.log not found</error>"
     for member in tar.getmembers():
         if "parser.log" in member.name:
@@ -329,7 +329,7 @@ def create_parser_log_xml(tar: tarfile.TarFile) -> str:
             else:
                 parser_log_contents = "Unable to read parser log file!"
             parser_log_value = f"<error>{parser_log_contents}</error>"
-    return parser_log_value
+    return parser_log_value.encode("utf-8")
 
 
 def update_published_documents(uri, s3_client: S3Client) -> None:
@@ -347,7 +347,7 @@ def update_published_documents(uri, s3_client: S3Client) -> None:
             s3_client.copy(source, public_bucket, key, extra_args)
 
 
-def parse_xml(xml: str) -> ET.Element:
+def parse_xml(xml: bytes) -> ET.Element:
     ET.register_namespace("", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0")
     ET.register_namespace("uk", "https://caselaw.nationalarchives.gov.uk/akn")
     return ET.XML(xml)
@@ -372,7 +372,7 @@ def _build_version_annotation_payload_from_metadata(metadata: TREMetadataDict) -
 def get_best_xml(uri, tar: tarfile.TarFile, xml_file_name: str, consignment_reference: str) -> ET.Element:
     xml_file = extract_xml_file(tar, xml_file_name)
     if xml_file:
-        contents = xml_file.read().decode("utf-8")  # We assume here that our XML is in UTF-8
+        contents = xml_file.read()
         try:
             return parse_xml(contents)
         except ET.ParseError:

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -83,13 +83,6 @@ class Metadata:
 
 class Message:
     @classmethod
-    def from_event(cls, event):
-        decoder = json.decoder.JSONDecoder()
-        message = decoder.decode(event["Records"][0]["Sns"]["Message"])
-        # passes a messagedict to the class
-        return cls.from_message(message)
-
-    @classmethod
     def from_message(cls, message: dict):
         if message.get("Records", [{}])[0].get("eventSource") == "aws:s3":
             return S3Message(message["Records"][0])

--- a/ds-caselaw-ingester/lambda_function.py
+++ b/ds-caselaw-ingester/lambda_function.py
@@ -303,7 +303,7 @@ def personalise_email(uri: str, metadata: TREMetadataDict) -> dict:
 
 
 def copy_file(
-    tarfile,
+    tarfile: tarfile.TarFile,
     input_filename: str,
     output_filename: str,
     output_location: S3PrefixString,
@@ -322,12 +322,15 @@ def copy_file(
         raise FileNotFoundException(f"File was not found: {input_filename}, files were {tarfile.getnames()} ") from err
 
 
-def create_parser_log_xml(tar) -> str:
+def create_parser_log_xml(tar: tarfile.TarFile) -> str:
     parser_log_value = "<error>parser.log not found</error>"
     for member in tar.getmembers():
         if "parser.log" in member.name:
             parser_log = tar.extractfile(member)
-            parser_log_contents = escape(parser_log.read().decode("utf-8"))
+            if parser_log is not None:
+                parser_log_contents = escape(parser_log.read().decode("utf-8"))
+            else:
+                parser_log_contents = "Unable to read parser log file!"
             parser_log_value = f"<error>{parser_log_contents}</error>"
     return parser_log_value
 

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -547,7 +547,7 @@ class TestLambda:
             mode="r",
         ) as tar:
             result = lambda_function.create_parser_log_xml(tar)
-            assert result == "<error>This is the parser error log.</error>"
+            assert result == b"<error>This is the parser error log.</error>"
 
     @patch.object(tarfile, "open")
     def test_create_xml_contents_failure(self, mock_open_tarfile):
@@ -557,7 +557,7 @@ class TestLambda:
         ) as tar:
             tar.extractfile = MagicMock(side_effect=KeyError)
             result = lambda_function.create_parser_log_xml(tar)
-            assert result == "<error>parser.log not found</error>"
+            assert result == b"<error>parser.log not found</error>"
 
     @patch.dict(
         os.environ,

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -19,6 +19,7 @@ from caselawclient.Client import (
 from caselawclient.factories import JudgmentFactory, PressSummaryFactory
 from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from caselawclient.models.identifiers.press_summary_ncn import PressSummaryRelatedNCNIdentifier
+from caselawclient.models.utilities.aws import S3PrefixString
 from notifications_python_client.notifications import NotificationsAPIClient
 
 rollbar.init(access_token=None, enabled=False)
@@ -336,7 +337,12 @@ class TestLambda:
     def test_store_file_success(self, mock_print):
         session = boto3.Session
         session.upload_fileobj = MagicMock()
-        lambda_function.store_file(None, "folder", "filename.ext", session)
+        lambda_function.store_file(
+            file=None,
+            destination_folder=S3PrefixString("folder/"),
+            destination_filename="filename.ext",
+            s3_client=session,
+        )
         mock_print.assert_called_with("Upload Successful folder/filename.ext")
         session.upload_fileobj.assert_called_with(None, ANY, "folder/filename.ext")
 
@@ -344,7 +350,12 @@ class TestLambda:
     def test_store_file_file_not_found(self, mock_print):
         session = boto3.Session
         session.upload_fileobj = MagicMock(side_effect=FileNotFoundError)
-        lambda_function.store_file(None, "folder", "filename.ext", session)
+        lambda_function.store_file(
+            file=None,
+            destination_folder=S3PrefixString("folder/"),
+            destination_filename="filename.ext",
+            s3_client=session,
+        )
         mock_print.assert_called_with("The file folder/filename.ext was not found")
         session.upload_fileobj.assert_called_with(None, ANY, "folder/filename.ext")
 
@@ -352,7 +363,12 @@ class TestLambda:
     def test_store_file_file_no_credentials(self, mock_print):
         session = boto3.Session
         session.upload_fileobj = MagicMock(side_effect=NoCredentialsError)
-        lambda_function.store_file(None, "folder", "filename.ext", session)
+        lambda_function.store_file(
+            file=None,
+            destination_folder=S3PrefixString("folder/"),
+            destination_filename="filename.ext",
+            s3_client=session,
+        )
         mock_print.assert_called_with("Credentials not available")
         session.upload_fileobj.assert_called_with(None, ANY, "folder/filename.ext")
 
@@ -508,7 +524,12 @@ class TestLambda:
             session = boto3.Session
             lambda_function.store_file = MagicMock()
             lambda_function.copy_file(tar, filename, "new_filename", "uri", session)
-            lambda_function.store_file.assert_called_with(ANY, ANY, ANY, ANY)
+            lambda_function.store_file.assert_called_with(
+                file=ANY,
+                destination_folder="uri",
+                destination_filename="new_filename",
+                s3_client=session,
+            )
 
     def test_copy_file_not_found(self):
         with tarfile.open(

--- a/ds-caselaw-ingester/tests.py
+++ b/ds-caselaw-ingester/tests.py
@@ -747,8 +747,8 @@ class TestLambda:
         )
         assert "2010+Reported" in my_raw
 
-        event = {"Records": [{"Sns": {"Message": my_raw}}]}
-        message = lambda_function.Message.from_event(event)
+        decoder = json.decoder.JSONDecoder()
+        message = lambda_function.Message.from_message(decoder.decode(my_raw))
         mock_s3_client = MagicMock()
         message.save_s3_response(None, mock_s3_client)
         mock_s3_client.download_file.assert_called_with(ANY, "2010 Reported/[2010]/1.tar.gz", ANY)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,4 +8,5 @@ notifications-python-client~=10.0
 
 mypy-boto3-s3
 mypy-boto3-sns
+mypy-boto3-sqs
 python-dotenv


### PR DESCRIPTION
Add several missing type annotations to the codebase, and make necessary adjustments where needed so that Python is being explicit about types rather than relying on implicit type conversions.

This gives us a more solid base for future refactoring work.