### PR TITLE
[FCL-674] Fix typo in deployed python version

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -72,7 +72,7 @@ Resources:
     Properties:
       CodeUri: ds-caselaw-ingester/
       Handler: lambda_function.handler
-      Runtime: python2
+      Runtime: python3.12
       Architectures:
         - x86_64
       Timeout: 420


### PR DESCRIPTION
We accidentally changed `python3.11` to `python2` instead of `python3.12`.