### PR TITLE
[FCL-733] Add new Ingester property to determine the type of document being ingested.

### DIFF
--- a/ds_caselaw_ingester/exceptions.py
+++ b/ds_caselaw_ingester/exceptions.py
@@ -37,3 +37,7 @@ class DocxFilenameNotFoundException(ReportableException):
 
 class DocumentInsertionError(ReportableException):
     pass
+
+
+class CannotDetermineDocumentType(ReportableException):
+    pass

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,29 @@
+from caselawclient.models.judgments import Judgment
+from caselawclient.models.press_summaries import PressSummary
+from pytest import raises
+
+from ds_caselaw_ingester.exceptions import CannotDetermineDocumentType
+from ds_caselaw_ingester.ingester import parse_xml
+
+
+class TestIngestProperties:
+    def test_ingested_document_type_judgment(self, v2_ingest):
+        """Check that documents with a root tag of `<judgment>` are detected as `Judgment`s."""
+        v2_ingest.xml = parse_xml(b"<judgment />")
+        assert v2_ingest.ingested_document_type == Judgment
+
+    def test_ingested_document_type_press_summary(self, v2_ingest):
+        """ "Check that documents with a root tag of `<doc name="pressSummary">` are detected as `PressSummary`s."""
+        v2_ingest.xml = parse_xml(b'<doc name="pressSummary" />')
+        assert v2_ingest.ingested_document_type == PressSummary
+
+    def test_ingested_document_type_doc_without_press_summary_name(self, v2_ingest):
+        """ "Check that documents with a root tag of `<doc>` but no `name="pressSummary" raise an exception."""
+        v2_ingest.xml = parse_xml(b"<doc />")
+        with raises(CannotDetermineDocumentType):
+            assert v2_ingest.ingested_document_type
+
+    def test_ingested_document_type_unknown(self, v2_ingest):
+        """Check that in the absence of typing information an exception is raised."""
+        with raises(CannotDetermineDocumentType):
+            assert v2_ingest.ingested_document_type


### PR DESCRIPTION
When a document is ingested, as currently deployed we rely on the presence of `press-summary` in the URI to hint at the type. As we move to abstract identifiers this falls apart, and instead we must rely on the content of the document itself to provide type hinting.

This adds a new property to the Ingest class to reflect the type of document being ingested, which can then be used in future to make sure we do things like correctly assign identifier types.

## Jira

FCL-733