### PR TITLE
Add `__init__.py` to attempt to make lambda happy

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,1 +1,1 @@
-python -m pytest tests/* $*
+AWS_BUCKET_NAME=x PUBLIC_ASSET_BUCKET=y python -m pytest tests/* $*


### PR DESCRIPTION
Add `__init__.py` to attempt to make lambda happy
The error was:

[ERROR] Runtime.ImportModuleError: Unable to import module 'lambda_function': attempted relative import with no known parent package
Traceback (most recent call last):

There was no traceback.