### PR TITLE
[FCL-733] Add new property to identify ingested document type based on XML root node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
           - types-python-dateutil
           - types-pytz
           - boto3-stubs[s3,sns]
-          - ds-caselaw-marklogic-api-client~=31.1.0
+          - ds-caselaw-marklogic-api-client~=34.0.0
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client==33.0.0
+ds-caselaw-marklogic-api-client==34.0.0
 requests-toolbelt~=1.0
 urllib3~=2.2
 boto3


### PR DESCRIPTION
This is just a facade through to the function in the API Client, so that when we harmonise document creation in future there's less potential friction.