### PR TITLE
Get local tests working with relative paths

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,11 @@ import copy
 import json
 from unittest.mock import Mock, patch
 
-from helpers import create_fake_bulk_file, create_fake_tdr_file
 from pytest import fixture
 
 from src.ds_caselaw_ingester import ingester, lambda_function
+
+from .helpers import create_fake_bulk_file, create_fake_tdr_file
 
 v2_message_raw = """
     {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,11 +12,12 @@ from caselawclient.Client import (
     MarklogicResourceNotFoundError,
 )
 from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
-from conftest import s3_message_raw, v2_message, v2_message_raw
-from helpers import create_fake_bulk_file, create_fake_tdr_file
 from notifications_python_client.notifications import NotificationsAPIClient
 
 from src.ds_caselaw_ingester import exceptions, ingester, lambda_function
+
+from .conftest import s3_message_raw, v2_message, v2_message_raw
+from .helpers import create_fake_bulk_file, create_fake_tdr_file
 
 rollbar.init(access_token=None, enabled=False)
 


### PR DESCRIPTION
## Changes in this PR:

On trying to make changes to make the ingester use the v34 api changes, the tests would not run cleanly locally.