### PR TITLE
v34 compatibility doctype

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
-        files: ^ds_caselaw_ingester/
+        files: ^src/ds_caselaw_ingester/
         language_version: "3.12"
         additional_dependencies:
           - types-requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client==34.0.0
+ds-caselaw-marklogic-api-client==34.0.1
 requests-toolbelt~=1.0
 urllib3~=2.2
 boto3

--- a/src/ds_caselaw_ingester/ingester.py
+++ b/src/ds_caselaw_ingester/ingester.py
@@ -214,10 +214,14 @@ class Metadata:
 
     @property
     def is_tdr(self) -> bool:
+        """Does the metadata say this document came from TDR?"""
         return "TDR" in self.parameters
 
     @property
     def force_publish(self) -> bool:
+        """
+        Does the metadata say to automatically publish this document?
+        """
         return self.parameters.get("INGESTER_OPTIONS", {}).get("auto_publish", False)
 
 
@@ -289,7 +293,12 @@ class Ingest:
                 _build_version_annotation_payload_from_metadata(self.metadata),
             ),  # We cast this to a dict here because VersionAnnotation doesn't yet have a TypedDict as its payload argument.
         )
-        self.api_client.insert_document_xml(self.uri, self.xml, annotation)
+        self.api_client.insert_document_xml(
+            document_uri=self.uri,
+            document_xml=self.xml,
+            annotation=annotation,
+            document_type=self.ingested_document_type,
+        )
         return True
 
     def set_document_identifiers(self) -> None:


### PR DESCRIPTION
API v34 adds a requirement that calls to `insert_document_xml` have a doctype; we add this by using the new document lookup.