### PR TITLE
Use apiclient Document class methods to publish and unpublish documents in ingester in consistent manner to editor ui

### DIFF
--- a/src/ds_caselaw_ingester/ingester.py
+++ b/src/ds_caselaw_ingester/ingester.py
@@ -390,7 +390,8 @@ class Ingest:
         pass
 
     def unpublish_updated_judgment(self) -> None:
-        self.api_client.set_published(self.uri, False)
+        document = Document(self.uri, self.api_client)
+        document.unpublish()
 
     def store_metadata(self) -> None:
         tdr_metadata = self.metadata["parameters"]["TDR"]
@@ -493,7 +494,8 @@ class Ingest:
         raise RuntimeError(f"Didn't recognise originator {originator!r}")
 
     def publish(self) -> None:
-        self.api_client.set_published(self.uri, True)
+        document = Document(self.uri, self.api_client)
+        document.publish()
 
     def send_email(self) -> None:
         originator = self.message.originator

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -485,12 +485,39 @@ class TestLambda:
         with pytest.raises(MarklogicCommunicationError):
             v2_ingest.insert_document_xml()
 
-    def test_unpublish_updated_judgment(self, v2_ingest):
+    @patch("caselawclient.models.documents.Document")
+    def test_unpublish_updated_judgment(self, MockDocument, v2_ingest):
+        # Mock the Document class
+        # mock_document_instance = MagicMock()
+        # MockDocument.side_effect = lambda _uri, _api_client: mock_document_instance
+
+        mock_document_instance = MockDocument.return_value
+        mock_document_instance.unpublish = MagicMock()
+
         uri = "a/fake/uri"
-        v2_ingest.api_client.set_published = MagicMock()
         v2_ingest.uri = uri
+
         v2_ingest.unpublish_updated_judgment()
-        v2_ingest.api_client.set_published.assert_called_with(uri, False)
+
+        MockDocument.assert_called_once_with(uri, v2_ingest.api_client)
+        mock_document_instance.unpublish.assert_called_once()
+
+    @patch("caselawclient.models.documents.Document")
+    def test_publish(self, MockDocument, v2_ingest):
+        # Mock the Document class
+        # mock_document_instance = MagicMock()
+        # MockDocument.side_effect = lambda _uri, _api_client: mock_document_instance
+
+        mock_document_instance = MockDocument.return_value
+        mock_document_instance.unpublish = MagicMock()
+
+        uri = "a/fake/uri"
+        v2_ingest.uri = uri
+
+        v2_ingest.publish()
+
+        MockDocument.assert_called_once_with(uri, v2_ingest.api_client)
+        mock_document_instance.publish.assert_called_once()
 
     def test_user_agent(self):
         assert "ingester" in lambda_function.api_client.session.headers["User-Agent"]


### PR DESCRIPTION
## Changes in this PR:

Use apiclient Document class methods to publish and unpublish documents in ingester in consistent manner to editor ui

## Jira card / Rollbar error (etc)