### PR TITLE
Reinstate handing out NCN-based URIs for the time-being

### DIFF
--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,5 +1,8 @@
 def test_fixture_load(v2_ingest, s3_ingest):
     """We get the XML of the data and extract the URI from it successfully using the fixtures"""
 
-    assert v2_ingest.uri == "d-v2-a1b2-c3d4"
-    assert s3_ingest.uri == "d-s3-a1b2-c3d4"
+    # assert v2_ingest.uri == "d-v2-a1b2-c3d4"
+    # assert s3_ingest.uri == "d-s3-a1b2-c3d4"
+
+    assert v2_ingest.uri == "ewca/civ/2022/111"
+    assert s3_ingest.uri == "ukut/iac/2012/82"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -118,7 +118,8 @@ class TestHandler:
         assert "publishing" in log
         assert "Invalid XML file" not in log
         assert "No XML file found" not in log
-        apiclient.set_published.assert_called_with("d-a1b2-c3d4", True)
+        # apiclient.set_published.assert_called_with("d-a1b2-c3d4", True)
+        apiclient.set_published.assert_called_with("ukut/iac/2012/82", True)
         assert apiclient.set_published.call_count == 2
         notify_new.assert_not_called()
         notify_updated.assert_not_called()


### PR DESCRIPTION
To allow us to better sequence some deploys, temporarily switch the ingester to handing out old-style NCN-based URIs