### PR TITLE
Persist credentials so Endbug can use them

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          persist-credentials: true
       - name: Run latest-tag
         uses: EndBug/latest-tag@latest
       - uses: actions/setup-python@v5


### PR DESCRIPTION
<!-- Describe what has changed in this PR, and why -->

Essentially the same as https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/1999/files
It's why 1.15 deploy is broken.

Do a release afterwards

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira
Not in Jira.