### PR TITLE
⚠️ [FCL-673] Assign all new documents UUID-based URIs

### DIFF
--- a/docs/uri_logic.md
+++ b/docs/uri_logic.md
@@ -24,11 +24,11 @@ flowchart TD
     URI_IN_PARSER_METADATA -- No --> DOCUMENT_HAS_NCN
     EXISTING_DOCUMENT_AT_URI -- No --> DOCUMENT_HAS_NCN
 
-    DOCUMENT_HAS_NCN{Is there an NCN present in the Parser metadata?}
+    DOCUMENT_HAS_NCN{Is there an existing document in MarkLogic with the NCN present in the Parser metadata?}
 
     DOCUMENT_HAS_NCN -- Yes --> EXISTING_DOCUMENT_AT_NCN
 
-    EXISTING_DOCUMENT_AT_NCN{Is there an existing document in MarkLogic with that NCN in the relevant identifier scheme?}
+    EXISTING_DOCUMENT_AT_NCN{Is there an NCN present in the Parser metadata?}
 
     EXISTING_DOCUMENT_AT_NCN -- Yes --> SET_URI_TO_EXISTING_DOC
 
@@ -36,11 +36,7 @@ flowchart TD
 
     DOCUMENT_HAS_NCN -- No --> GENERATE_UUID_URI
 
-    GENERATE_NCN_URI[Generate new NCN-based URI]
-    GENERATE_NCN_URI --> SET_URI_TO_NCN
-    SET_URI_TO_NCN(["Return a tuple of (uri=new NCN-based URI, exists=False)"])
-
-    EXISTING_DOCUMENT_AT_NCN -- No --> GENERATE_NCN_URI
+    EXISTING_DOCUMENT_AT_NCN -- No --> GENERATE_UUID_URI
 
     GENERATE_UUID_URI[Generate new UUID-based URI]
     GENERATE_UUID_URI --> SET_URI_TO_UUID

--- a/docs/uri_logic.md
+++ b/docs/uri_logic.md
@@ -19,22 +19,24 @@ flowchart TD
 
     EXISTING_DOCUMENT_AT_URI -- Yes --> SET_URI_TO_EXISTING_DOC
 
+    URI_IN_PARSER_METADATA -- No --> NCN_IN_PARSER_METADATA
+    EXISTING_DOCUMENT_AT_URI -- No --> NCN_IN_PARSER_METADATA
 
+    NCN_IN_PARSER_METADATA{Is an NCN present in the Parser metadata?}
 
-    URI_IN_PARSER_METADATA -- No --> DOCUMENT_HAS_NCN
-    EXISTING_DOCUMENT_AT_URI -- No --> DOCUMENT_HAS_NCN
+    NCN_IN_PARSER_METADATA -- Yes --> FIND_DOCUMENT_ID_SCHEMA
 
-    DOCUMENT_HAS_NCN{Is there an existing document in MarkLogic with the NCN present in the Parser metadata?}
+    FIND_DOCUMENT_ID_SCHEMA[Find correct ID schema for document]
 
-    DOCUMENT_HAS_NCN -- Yes --> EXISTING_DOCUMENT_AT_NCN
+    FIND_DOCUMENT_ID_SCHEMA --> EXISTING_DOCUMENT_AT_NCN
 
-    EXISTING_DOCUMENT_AT_NCN{Is there an NCN present in the Parser metadata?}
+    EXISTING_DOCUMENT_AT_NCN{Is there an existing document in MarkLogic with matching NCN and schema?}
 
     EXISTING_DOCUMENT_AT_NCN -- Yes --> SET_URI_TO_EXISTING_DOC
 
     SET_URI_TO_EXISTING_DOC(["Return a tuple of (uri=existing document URI, exists=True)"])
 
-    DOCUMENT_HAS_NCN -- No --> GENERATE_UUID_URI
+    NCN_IN_PARSER_METADATA -- No --> GENERATE_UUID_URI
 
     EXISTING_DOCUMENT_AT_NCN -- No --> GENERATE_UUID_URI
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -670,7 +670,7 @@ class TestDatabaseLocation:
     https://github.com/nationalarchives/ds-caselaw-ingester/pull/311/files?short_path=81f315b#diff-81f315ba06f2786cef4c0a1d091d65b650897a6296ae371952d8475cef5d8b5e
     """
 
-    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="uuid")
+    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="a1b2c3")
     def test_nn_no_parser_uri_or_ncn(self, uuid, v2_ingest):
         v2_ingest.api_client.resolve_from_identifier_value.return_value = []
         v2_ingest.api_client.resolve_from_identifier_slug.return_value = []
@@ -678,7 +678,7 @@ class TestDatabaseLocation:
         v2_ingest.extracted_ncn = None
         uri, exists = v2_ingest.database_location
         assert isinstance(uri, DocumentURIString)
-        assert str(uri) == "d-uuid"
+        assert str(uri) == "d-a1b2c3"
         assert exists is False
 
     @patch("src.ds_caselaw_ingester.ingester.Metadata.trimmed_uri", new_callable=PropertyMock, return_value="uri")
@@ -689,7 +689,7 @@ class TestDatabaseLocation:
         assert exists is True
 
     @patch("src.ds_caselaw_ingester.ingester.Metadata.trimmed_uri", new_callable=PropertyMock, return_value="uri")
-    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="uuid")
+    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="a1b2c3")
     def test_ynyn_neither_uri_or_ncn_in_marklogic(self, uuid, trimmed_uri, v2_ingest):
         v2_ingest.api_client.resolve_from_identifier_slug.return_value = []
         v2_ingest.api_client.resolve_from_identifier_value.return_value = []
@@ -697,11 +697,11 @@ class TestDatabaseLocation:
         uri, exists = v2_ingest.database_location
         v2_ingest.api_client.resolve_from_identifier_slug.assert_called()
         v2_ingest.api_client.resolve_from_identifier_value.assert_called()
-        assert str(uri) == "d-uuid"
+        assert str(uri) == "d-a1b2c3"
         assert exists is False
 
     @patch("src.ds_caselaw_ingester.ingester.Metadata.trimmed_uri", new_callable=PropertyMock, return_value="uri")
-    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="uuid")
+    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="a1b2c3")
     def test_ynyy_ncn_in_marklogic(self, uuid, trimmed_uri, v2_ingest):
         v2_ingest.api_client.resolve_from_identifier_slug.return_value = []
         v2_ingest.api_client.resolve_from_identifier_value.return_value = [
@@ -715,7 +715,7 @@ class TestDatabaseLocation:
         assert exists is True
 
     @patch("src.ds_caselaw_ingester.ingester.Metadata.trimmed_uri", new_callable=PropertyMock, return_value="uri")
-    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="uuid")
+    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="a1b2c3")
     def test_ynn_uri_but_not_in_marklogic_no_ncn(self, uuid, trimmed_uri, v2_ingest):
         v2_ingest.api_client.resolve_from_identifier_slug.return_value = []
         v2_ingest.api_client.resolve_from_identifier_value.return_value = []
@@ -724,7 +724,7 @@ class TestDatabaseLocation:
         v2_ingest.api_client.resolve_from_identifier_value.assert_not_called()
 
         uri, exists = v2_ingest.database_location
-        assert str(uri) == "d-uuid"
+        assert str(uri) == "d-a1b2c3"
         assert exists is False
 
     @patch("src.ds_caselaw_ingester.ingester.Metadata.trimmed_uri", new_callable=PropertyMock, return_value="")
@@ -742,12 +742,12 @@ class TestDatabaseLocation:
         assert exists is True
 
     @patch("src.ds_caselaw_ingester.ingester.Metadata.trimmed_uri", new_callable=PropertyMock, return_value="")
-    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="uuid")
+    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="a1b2c3")
     def test_nyn_no_parser_uri_or_existing_doc_but_ncn_metdata(self, fake_uuid, trimmed_uri, v2_ingest):
         v2_ingest.api_client.resolve_from_identifier_value.return_value = []
         v2_ingest.extracted_ncn = "[2030] UKSC 999"
 
         uri, exists = v2_ingest.database_location
         v2_ingest.api_client.resolve_from_identifier_value.assert_called()
-        assert str(uri) == "d-uuid"
+        assert str(uri) == "d-a1b2c3"
         assert exists is False

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -697,7 +697,7 @@ class TestDatabaseLocation:
         uri, exists = v2_ingest.database_location
         v2_ingest.api_client.resolve_from_identifier_slug.assert_called()
         v2_ingest.api_client.resolve_from_identifier_value.assert_called()
-        assert str(uri) == "ewca/civ/2022/111"
+        assert str(uri) == "d-uuid"
         assert exists is False
 
     @patch("src.ds_caselaw_ingester.ingester.Metadata.trimmed_uri", new_callable=PropertyMock, return_value="uri")
@@ -742,11 +742,12 @@ class TestDatabaseLocation:
         assert exists is True
 
     @patch("src.ds_caselaw_ingester.ingester.Metadata.trimmed_uri", new_callable=PropertyMock, return_value="")
-    def test_nyn_no_parser_uri_or_existing_doc_but_ncn_metdata(self, trimmed_uri, v2_ingest):
+    @patch("src.ds_caselaw_ingester.ingester.uuid4", return_value="uuid")
+    def test_nyn_no_parser_uri_or_existing_doc_but_ncn_metdata(self, fake_uuid, trimmed_uri, v2_ingest):
         v2_ingest.api_client.resolve_from_identifier_value.return_value = []
         v2_ingest.extracted_ncn = "[2030] UKSC 999"
 
         uri, exists = v2_ingest.database_location
         v2_ingest.api_client.resolve_from_identifier_value.assert_called()
-        assert str(uri) == "uksc/2030/999"
+        assert str(uri) == "d-uuid"
         assert exists is False


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCL-673

Change the logic so that a document's URI is _always_ either an existing URI, or a new UUID-based one. We no longer mint new NCN-based URIs for any document, even if an NCN is present in the metadata.

⚠️ A significant change: once we deploy this, we will not be able to easily roll-back the PUI without exposing UUID based URIs.


<!-- Describe what has changed in this PR, and why -->

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram
