### PR TITLE
SNS_TOPIC environment variable populated from terraform

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -50,6 +50,9 @@ Parameters:
   RollbarToken:
     Description: "ROLLBAR_TOKEN"
     Type: "String"
+  SnsTopic:
+    Description: "SNS_TOPIC"
+    Type: "String"
   SqsQueueUrl:
     Description: "SQS_QUEUE_URL"
     Type: "String"
@@ -91,6 +94,7 @@ Resources:
           PUBLIC_ASSET_BUCKET: !Ref PublicAssetBucket
           ROLLBAR_ENV: !Ref RollbarEnv
           ROLLBAR_TOKEN: !Ref RollbarToken
+          SNS_TOPIC: !Ref SnsTopic
           SQS_QUEUE_URL: !Ref SqsQueueUrl
       VpcConfig:
         SubnetIds:


### PR DESCRIPTION
<!-- Describe what has changed in this PR, and why -->

https://dxw.slack.com/archives/C04UH0DHR2B/p1745508204194199

The SNS_TOPIC environment variable is blown away on deploy because it's a new lambda each time; this needs to be set up by Terraform.

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram
- [x] Relevant environment variables need to be set in Github for both staging and production.

## Jira

https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-825