### PR TITLE
Specify Ingester Lambda MemorySize of 256MB

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -76,6 +76,7 @@ Resources:
       CodeUri: src/
       Handler: ds_caselaw_ingester.lambda_function.handler
       Runtime: python3.12
+      MemorySize: 256
       Architectures:
         - x86_64
       Timeout: 420


### PR DESCRIPTION
Specified Ingester Lambda MemorySize of 256MB in cloudformation config

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

https://national-archives.atlassian.net/browse/FCL-895
