### PR TITLE
[FCL-1050] Bandit, but suppress warnings about tmp/filename.tar.gz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,14 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ", "T10", "DJ", "EXE" ]
-# extend-select = [ "S", "EM", "FA",
-#                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
-#                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
+extend-select = ["G", "W", "I", "SLF", "SIM", "B", "Q", "A", "COM", "C90", "UP", "YTT", "ASYNC", "BLE", "C4", "DTZ", "T10", "DJ", "EXE", "S"]
+# extend-select = ["EM", "FA", "ISC", "ICN", "INP", "PIE", "T20", "PYI", "PT", "RSE", "RET",
+#                  "SLOT", "TID", "TCH", "INT", "PTH", "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]
 
 [tool.ruff.lint.extend-per-file-ignores]
-"tests/*" = ["S101"]  # `assert` is fine in tests
+"*" = ["S108"] # insecure hardcoded temp file name -- fix at some point?
+"tests/*" = ["S101"]   # `assert` is fine in tests
 
 # things skipped:
 # N: naming, possibly good
@@ -18,7 +18,6 @@ unfixable = ["ERA"]
 # ANN: annotations missing throughout
 # FBT: not convinced boolean trap worth auto-banning.
 # CPY: copyright at top of each file
-# G: logging warnings -- fstrings bad?
 # ARG: sometimes you need to accept arguments.
 # TD: somewhat finicky details about formatting TODOs
 # FIX: flags todos: possible to add -- skipped for now


### PR DESCRIPTION
<!-- Describe what has changed in this PR, and why -->

Allow most bandit checks.
Specifically turn off checks for [S108](https://docs.astral.sh/ruff/rules/hardcoded-temp-file/) for now

> The use of hardcoded paths for temporary files can be insecure. If an attacker discovers the location of a hardcoded path, they can replace the contents of the file or directory with a malicious payload. 
> Other programs may also read or write contents to these hardcoded paths, causing unexpected behavior.

Also turned on "G", which warns about dodgy logging formats.

## Checklist

- [ ] I have updated docstrings as needed
- [ ] I've checked that any changes to the application logic are reflected in the docs
- [ ] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Origin
https://my.slack.com/archives/C04FQ3GFGUQ/p1752504806313179?thread_ts=1752500939.154289&cid=C04FQ3GFGUQ