### PR TITLE
Upload lambda to localstack s3 first to avoid 50 meg filesize limit

### DIFF
--- a/scripts/setup-localstack.sh
+++ b/scripts/setup-localstack.sh
@@ -1,4 +1,5 @@
 source .env
+export AWS_PAGER=""
 
 awslocal iam create-role \
   --role-name lambda-role \


### PR DESCRIPTION
When deploying to real AWS, we upload to S3 and then create the lambda, which has a 250 meg limit; we move towards that model when running locally, so that we're not impeded by the 50 meg limit (we're at about 60.)

https://stackoverflow.com/questions/64875438

It's still broken, but not in this way.

<!-- Describe what has changed in this PR, and why -->

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram
