### PR TITLE
Remove failing codeclimate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,5 @@ jobs:
       - name: Run tests with coverage
         run: coverage run -m pytest tests/*
 
-      - name: Generate coverage XML
-        run: coverage xml
-
-      - name: Upload coverage to CodeClimate
-        uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7 # v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      # - name: Generate coverage XML
+      #   run: coverage xml


### PR DESCRIPTION
Whilst the error

```
/home/runner/work/ds-caselaw-ingester/ds-caselaw-ingester/cc-reporter before-build
ℹ️ 'coverageCommand' not set, so skipping building coverage report!
```

implies a configuration error, codeclimate is being shut down imminently, so turn this check off.

There's no discernable reason why this should have suddenly started to fail other than the turn off...

<!-- Describe what has changed in this PR, and why -->

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram
