### PR TITLE
FCL-1172: Rely on API client to upload documents to public S3 bucket

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -149,7 +149,6 @@ sequenceDiagram
 
         alt Document is set to auto-publish
             perform_ingest ->> document: publish()
-            perform_ingest ->>+ Ingest: update_published_documents()
             Ingest <<->> S3_unpublished : Get list of assets with document prefix
             loop For each asset
                 Ingest ->> S3_published : Copy asset to published bucket

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -393,30 +393,6 @@ class TestLambda:
         )
         mock_print.assert_called_with(Contains("Sent update notification to test@notifications.service.gov.uk"))
 
-    @patch("src.ds_caselaw_ingester.ingester.PRIVATE_ASSET_BUCKET", "private-bucket")
-    def test_update_published_documents(self, v2_ingest):
-        contents = {"Contents": [{"Key": "file1.ext"}, {"Key": "file2.ext"}]}
-
-        v2_ingest.s3_client.list_objects = MagicMock(return_value=contents)
-        v2_ingest.s3_client.copy = MagicMock()
-
-        calls = [
-            call(
-                {"Bucket": "private-bucket", "Key": "file1.ext"},
-                "public-bucket",
-                "file1.ext",
-                {},
-            ),
-            call(
-                {"Bucket": "private-bucket", "Key": "file2.ext"},
-                "public-bucket",
-                "file2.ext",
-                {},
-            ),
-        ]
-        v2_ingest.update_published_documents("public-bucket")
-        v2_ingest.s3_client.copy.assert_has_calls(calls)
-
     def test_get_consignment_reference_success_v2(self):
         message = copy.deepcopy(v2_message)
         message["parameters"]["reference"] = "THIS_REF"


### PR DESCRIPTION
<!-- Describe what has changed in this PR, and why -->
https://national-archives.atlassian.net/browse/FCL-1172

Currently we upload documents twice to the public S3 bucket -- once in the API and once in the ingester. The ingester should give up this responsibility