### PR TITLE
fix: bump apiclient to 45.0.0 to hopefully fix memory leak

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
           - types-python-dateutil==2.9.0.20260408
           - types-pytz==2026.1.1.20260408
           - boto3-stubs[s3,sns]==1.42.91
-          - ds-caselaw-marklogic-api-client==44.5.0
+          - ds-caselaw-marklogic-api-client==45.0.0
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client==44.5.0
+ds-caselaw-marklogic-api-client==45.0.0
 requests-toolbelt~=1.0
 urllib3~=2.2
 boto3


### PR DESCRIPTION
fix: bump apiclient to 45.0.0 to hopefully fix memory leak

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira
FCLC-123