### PR TITLE
fix: Move apiclient init into lambda handler to fix memory leak

### DIFF
--- a/src/ds_caselaw_ingester/lambda_function.py
+++ b/src/ds_caselaw_ingester/lambda_function.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 from urllib.parse import unquote_plus
 
 import boto3
-import boto3.s3
 import rollbar
 from caselawclient.Client import (
     DEFAULT_USER_AGENT,
@@ -34,14 +33,6 @@ MARKLOGIC_PASSWORD: str = os.environ["MARKLOGIC_PASSWORD"]
 MARKLOGIC_USE_HTTPS: bool = bool(os.getenv("MARKLOGIC_USE_HTTPS", default=False))
 
 PRIVATE_ASSET_BUCKET: str = os.environ["PRIVATE_ASSET_BUCKET"]
-
-api_client = MarklogicApiClient(
-    host=MARKLOGIC_HOST,
-    username=MARKLOGIC_USER,
-    password=MARKLOGIC_PASSWORD,
-    use_https=MARKLOGIC_USE_HTTPS,
-    user_agent=f"ds-caselaw-ingester/unknown {DEFAULT_USER_AGENT}",
-)
 
 
 class Message(ABC):
@@ -182,6 +173,14 @@ def get_s3_client() -> S3Client:
 
 @rollbar.lambda_function
 def handler(event, context):
+    api_client = MarklogicApiClient(
+        host=MARKLOGIC_HOST,
+        username=MARKLOGIC_USER,
+        password=MARKLOGIC_PASSWORD,
+        use_https=MARKLOGIC_USE_HTTPS,
+        user_agent=f"ds-caselaw-ingester/unknown {DEFAULT_USER_AGENT}",
+    )
+
     s3_client = get_s3_client()
     batch_item_failures = []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,24 @@
 import copy
 import json
+import os
 import tarfile
 from unittest.mock import Mock, PropertyMock, patch
 
-from caselawclient.types import DocumentURIString
-from pytest import fixture
+# Mock required environment variables before importing the lambda module,
+# as it reads them at import time via os.environ[...]
+os.environ.setdefault("MARKLOGIC_HOST", "test-marklogic-host")
+os.environ.setdefault("MARKLOGIC_USER", "test-user")
+os.environ.setdefault("MARKLOGIC_PASSWORD", "test-password")
+os.environ.setdefault("PRIVATE_ASSET_BUCKET", "test-private-bucket")
+os.environ.setdefault("PUBLIC_ASSET_BUCKET", "test-public-bucket")
+os.environ.setdefault("NOTIFY_API_KEY", "test-notify-key")
 
-from src.ds_caselaw_ingester import ingester, lambda_function
+from caselawclient.types import DocumentURIString  # noqa: E402
+from pytest import fixture  # noqa: E402
 
-from .helpers import create_fake_bulk_file, create_fake_tdr_file
+from src.ds_caselaw_ingester import ingester, lambda_function  # noqa: E402
+
+from .helpers import create_fake_bulk_file, create_fake_tdr_file  # noqa: E402
 
 
 def setup_api_client():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,7 +40,7 @@ def assert_log_sensible(log):
 
 
 class TestHandler:
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
@@ -70,7 +70,7 @@ class TestHandler:
         capsys,
     ):
         boto_session.return_value.client.return_value.download_file = create_fake_tdr_file
-        doc = apiclient.get_document_by_uri.return_value
+        doc = apiclient.return_value.get_document_by_uri.return_value
         doc.neutral_citation = None
         mock_doc.return_value = doc
 
@@ -98,7 +98,7 @@ class TestHandler:
         doc.identifiers.add.assert_not_called()
         doc.identifiers.save.assert_not_called()
 
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
@@ -132,7 +132,7 @@ class TestHandler:
         """Test that, with appropriate stubs, an S3 message passes through the parsing process"""
         boto_session.return_value.client.return_value.download_file = create_fake_bulk_file
         mock_uuid4.return_value = "a1b2-c3d4"
-        doc = apiclient.get_document_by_uri.return_value
+        doc = apiclient.return_value.get_document_by_uri.return_value
         doc.neutral_citation = "[2012] UKUT 82 (IAC)"
         mock_doc.return_value = doc
 
@@ -166,7 +166,7 @@ class TestHandler:
         assert type(doc.identifiers.add.call_args_list[0].args[0]) is NeutralCitationNumber
         doc.save_identifiers.assert_called()
 
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
@@ -191,7 +191,7 @@ class TestHandler:
         capsys,
     ):
         boto_session.return_value.client.return_value.download_file = create_fake_error_file
-        mock_doc.return_value = apiclient.get_document_by_uri.return_value
+        mock_doc.return_value = apiclient.return_value.get_document_by_uri.return_value
 
         message = error_message_raw
 
@@ -237,7 +237,7 @@ class TestHandler:
     )
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
     @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     def test_handler_exception_handled(
         self,
         mock_api_client,
@@ -557,7 +557,14 @@ class TestLambda:
         assert call.args[3] == "v2-a1b2-c3d4.docx"
 
     def test_user_agent(self):
-        assert "ingester" in lambda_function.api_client.session.headers["User-Agent"]
+        """The handler must construct the MarklogicApiClient with an 'ingester' User-Agent."""
+        with (
+            patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient") as mock_client,
+            patch("src.ds_caselaw_ingester.lambda_function.all_messages", return_value=[]),
+        ):
+            lambda_function.handler(event={"Records": []}, context=None)
+        kwargs = mock_client.call_args.kwargs
+        assert "ingester" in kwargs["user_agent"]
 
     @patch("os.path.exists", return_value=True)
     @patch("os.getenv", return_value="")

--- a/tests/test_sqs_handler.py
+++ b/tests/test_sqs_handler.py
@@ -14,7 +14,7 @@ from .test_main import assert_log_sensible
 class TestSQSHandler:
     """Tests for SQS event handling (SNS → SQS → Lambda path)."""
 
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
@@ -45,7 +45,7 @@ class TestSQSHandler:
     ):
         """Test that a V2 message arriving via SQS is processed correctly."""
         boto_session.return_value.client.return_value.download_file = create_fake_tdr_file
-        doc = apiclient.get_document_by_uri.return_value
+        doc = apiclient.return_value.get_document_by_uri.return_value
         doc.neutral_citation = None
         mock_doc.return_value = doc
 
@@ -58,7 +58,7 @@ class TestSQSHandler:
         # No failures → empty batchItemFailures
         assert result == {"batchItemFailures": []}
 
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
@@ -92,7 +92,7 @@ class TestSQSHandler:
         """Test that an S3 message arriving via SQS is processed correctly."""
         boto_session.return_value.client.return_value.download_file = create_fake_bulk_file
         mock_uuid4.return_value = "a1b2-c3d4"
-        doc = apiclient.get_document_by_uri.return_value
+        doc = apiclient.return_value.get_document_by_uri.return_value
         doc.neutral_citation = "[2012] UKUT 82 (IAC)"
         mock_doc.return_value = doc
 
@@ -110,7 +110,7 @@ class TestSQSHandler:
     )
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
     @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     def test_sqs_handler_returns_batch_item_failures(
         self,
         mock_api_client,
@@ -135,7 +135,7 @@ class TestSQSHandler:
     )
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
     @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     def test_sqs_handler_partial_batch_failure(
         self,
         mock_api_client,
@@ -177,7 +177,7 @@ class TestSQSHandler:
     )
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
     @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
     def test_sns_handler_still_works(
         self,
         mock_api_client,


### PR DESCRIPTION
fix: Move apiclient init into lambda handler to HOPEFULLY fix memory leak

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira


FCL-
