### PR TITLE
feat(terraform)!: split SNS subscriptions for TRE and bulk-ingest S3 topics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,8 @@ jobs:
     secrets:
       AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
       TF_BACKEND_BUCKET: ${{ secrets.TF_BACKEND_BUCKET }}
-      TF_VAR_SNS_TOPIC_ARNS: ${{ secrets.TF_VAR_SNS_TOPIC_ARNS }}
+      TF_VAR_TRE_MESSAGE_TOPIC_ARN: ${{ secrets.TF_VAR_TRE_MESSAGE_TOPIC_ARN }}
+      TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN: ${{ secrets.TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN }}
 
   build-deploy:
     needs: [set-env, terraform]

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -14,8 +14,11 @@ on:
       TF_BACKEND_BUCKET:
         description: "S3 bucket for Terraform state"
         required: true
-      TF_VAR_SNS_TOPIC_ARNS:
-        description: "JSON list of SNS topic ARNs"
+      TF_VAR_TRE_MESSAGE_TOPIC_ARN:
+        description: "SNS topic ARN that publishes TRE messages (CourtDocumentPackageAvailable etc.)"
+        required: true
+      TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN:
+        description: "SNS topic ARN that fans out raw S3 ObjectCreated:* event notifications"
         required: true
     outputs:
       ingest_queue_arn:
@@ -59,7 +62,8 @@ jobs:
       id-token: write
     env:
       TF_VAR_environment: ${{ inputs.environment }}
-      TF_VAR_sns_topic_arns: ${{ secrets.TF_VAR_SNS_TOPIC_ARNS }}
+      TF_VAR_tre_message_topic_arn: ${{ secrets.TF_VAR_TRE_MESSAGE_TOPIC_ARN }}
+      TF_VAR_bulk_ingest_s3_event_topic_arn: ${{ secrets.TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -59,9 +59,12 @@ terraform apply
 
 Set via `TF_VAR_*` environment variables or `-var`:
 
-| Variable         | Description                                 |
-| ---------------- | ------------------------------------------- |
-| `environment`    | Environment name (`staging`, `production`)  |
-| `sns_topic_arns` | JSON list of SNS topic ARNs to subscribe to |
+| Variable                         | Description                                                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `environment`                    | Environment name (`staging`, `production`)                                                                      |
+| `tre_message_topic_arn`          | SNS topic ARN that publishes TRE messages (filtered to `CourtDocumentPackageAvailable`)                         |
+| `bulk_ingest_s3_event_topic_arn` | SNS topic ARN that fans out raw S3 event notifications for the bulk-ingest path (filtered to `ObjectCreated:*`) |
+
+In CI these are passed via the `TF_VAR_TRE_MESSAGE_TOPIC_ARN` and `TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN` GitHub Actions secrets.
 
 All other variables have sensible defaults. See `terraform/variables.tf` for the full list.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,7 +35,7 @@ module "ingest_queue" {
         Resource  = "*"
         Condition = {
           ArnEquals = {
-            "aws:SourceArn" = var.sns_topic_arns
+            "aws:SourceArn" = [var.tre_message_topic_arn, var.bulk_ingest_s3_event_topic_arn]
           }
         }
       },
@@ -60,19 +60,17 @@ module "ingest_queue" {
   })
 }
 
-# Subscribe the SQS queue to each SNS topic.
-# This requires sns:Subscribe permission on the topic. If the topic is in
-# another account or you lack permission, remove this resource and ask the
-# topic owner to create the subscription pointing at the queue ARN in outputs.
+# Subscriptions to TRE message topics.
 #
-# A message-body filter policy is applied so that only ingestible
-# CourtDocumentPackageAvailable messages are delivered to the queue.
-# All other message types published on these topics are dropped at the
-# SNS layer and never reach the ingester Lambda.
-resource "aws_sns_topic_subscription" "ingest_queue_subscription" {
-  for_each = toset(var.sns_topic_arns)
-
-  topic_arn            = each.value
+# These topics carry application-level TRE messages with a `properties.messageType`
+# discriminator. Only `CourtDocumentPackageAvailable` messages are delivered to
+# the ingest queue; all other message types are dropped at the SNS layer.
+#
+# Requires sns:Subscribe permission on each topic. If the topic is in another
+# account or you lack permission, remove this resource and ask the topic owner
+# to create the subscription pointing at the queue ARN in outputs.
+resource "aws_sns_topic_subscription" "tre_message_subscription" {
+  topic_arn            = var.tre_message_topic_arn
   protocol             = "sqs"
   endpoint             = module.ingest_queue.sqs_arn
   raw_message_delivery = false # Preserve SNS envelope for auditability
@@ -83,6 +81,26 @@ resource "aws_sns_topic_subscription" "ingest_queue_subscription" {
       messageType = [
         "uk.gov.nationalarchives.tre.messages.courtdocumentpackage.available.CourtDocumentPackageAvailable",
       ]
+    }
+  })
+}
+
+# Subscriptions to SNS topics that fan out raw S3 event notifications.
+#
+# S3 event payloads use a different envelope (`Records[].eventName`), so they
+# need a distinct filter policy. The `prefix` match covers all `ObjectCreated:*`
+# variants (Put, Post, Copy, CompleteMultipartUpload) so multipart uploads are
+# not silently dropped.
+resource "aws_sns_topic_subscription" "bulk_ingest_s3_event_subscription" {
+  topic_arn            = var.bulk_ingest_s3_event_topic_arn
+  protocol             = "sqs"
+  endpoint             = module.ingest_queue.sqs_arn
+  raw_message_delivery = false # Preserve SNS envelope for auditability
+
+  filter_policy_scope = "MessageBody"
+  filter_policy = jsonencode({
+    Records = {
+      eventName = [{ prefix = "ObjectCreated:" }]
     }
   })
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,9 +9,24 @@ variable "aws_region" {
   default     = "eu-west-2"
 }
 
-variable "sns_topic_arns" {
-  description = "List of SNS topic ARNs that publish ingest messages"
-  type        = list(string)
+variable "tre_message_topic_arn" {
+  description = <<-EOT
+    SNS topic ARN that publishes TRE messages (envelope shape:
+    `{ "properties": { "messageType": "..." }, ... }`).
+    The subscription to this topic is filtered to only deliver
+    `CourtDocumentPackageAvailable` messages to the ingest queue.
+  EOT
+  type        = string
+}
+
+variable "bulk_ingest_s3_event_topic_arn" {
+  description = <<-EOT
+    SNS topic ARN that fans out raw S3 event notifications
+    (envelope shape: `{ "Records": [ { "eventName": "ObjectCreated:*", "s3": {...} } ] }`).
+    The subscription to this topic is filtered to only deliver
+    `ObjectCreated:*` events to the ingest queue.
+  EOT
+  type        = string
 }
 
 variable "message_retention_seconds" {


### PR DESCRIPTION
split SNS subscriptions for TRE and bulk-ingest S3 topics

Two named subscriptions instead of one parametrised `for_each`, each with the filter for its own envelope shape:
- `tre_message_subscription` — `properties.messageType` == `CourtDocumentPackageAvailable`
- `bulk_ingest_s3_event_subscription` — `Records[].eventName` prefix `ObjectCreated:` (covers multipart, not just `Put`)

tested the bulk s3 filter in aws console and it works as expected - letting the desired messages through!
<img width="1081" height="574" alt="Screenshot 2026-04-23 at 15 42 43" src="https://github.com/user-attachments/assets/4251fe8f-e0d6-427f-8c3d-8d6512aa3536" />

BREAKING CHANGE: `var.sns_topic_arns` -> `var.tre_message_topic_arn` + `var.bulk_ingest_s3_event_topic_arn`. Rename the matching GH Actions secrets and `terraform state mv` existing subs before applying.


## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

Required CI/CD changes. Must set:
- [x] `TF_VAR_TRE_MESSAGE_TOPIC_ARN`
-  [x] `TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN`

- [x] can remove: `TF_VAR_SNS_TOPIC_ARNS`

## Jira

FCL-
