### PR TITLE
ci: allow manual triggering of any branch to staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to deploy to" # This will always deploy to staging because of the set-env job but giving a false option here makes it clear that it won't be going to prod
+        required: true
+        type: choice
+        options:
+          - staging
   release:
     types: [published]
 


### PR DESCRIPTION
Sometimes we want to test changes to the ingester in a deployed environment before merging to main - this change allows us to push any branch to staging

## Checklist

- [ ] I have updated docstrings as needed
- [ ] I've checked that any changes to the application logic are reflected in the docs
- [ ] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

<!-- What Jira ticket does this correspond to? All work should have a ticket (although multiple PRs may share the same one) -->

No Jira ticket
