### PR TITLE
Move Marklogic client and AWS client outside of handler

### DIFF
--- a/src/ds_caselaw_ingester/lambda_function.py
+++ b/src/ds_caselaw_ingester/lambda_function.py
@@ -34,6 +34,15 @@ MARKLOGIC_USE_HTTPS: bool = bool(os.getenv("MARKLOGIC_USE_HTTPS", default=False)
 
 PRIVATE_ASSET_BUCKET: str = os.environ["PRIVATE_ASSET_BUCKET"]
 
+api_client = MarklogicApiClient(
+    host=MARKLOGIC_HOST,
+    username=MARKLOGIC_USER,
+    password=MARKLOGIC_PASSWORD,
+    use_https=MARKLOGIC_USE_HTTPS,
+    user_agent=f"ds-caselaw-ingester/unknown {DEFAULT_USER_AGENT}",
+)
+logger.info("Initialised MarkLogic API client")
+
 
 class Message(ABC):
     @classmethod
@@ -175,15 +184,6 @@ def get_s3_client() -> S3Client:
 @rollbar.lambda_function
 def handler(event, context):
     logger.info("Received event")
-
-    api_client = MarklogicApiClient(
-        host=MARKLOGIC_HOST,
-        username=MARKLOGIC_USER,
-        password=MARKLOGIC_PASSWORD,
-        use_https=MARKLOGIC_USE_HTTPS,
-        user_agent=f"ds-caselaw-ingester/unknown {DEFAULT_USER_AGENT}",
-    )
-    logger.info("Initialised MarkLogic API client")
 
     s3_client = get_s3_client()
     batch_item_failures = []

--- a/src/ds_caselaw_ingester/lambda_function.py
+++ b/src/ds_caselaw_ingester/lambda_function.py
@@ -43,6 +43,17 @@ api_client = MarklogicApiClient(
 )
 logger.info("Initialised MarkLogic API client")
 
+if os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_KEY") and os.getenv("AWS_ENDPOINT_URL"):
+    session = boto3.session.Session(
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_KEY"),
+    )
+    s3_client = session.client("s3", endpoint_url=os.getenv("AWS_ENDPOINT_URL"))
+else:
+    session = boto3.session.Session()
+    s3_client = session.client("s3")
+logger.info("Initialised S3 client")
+
 
 class Message(ABC):
     @classmethod
@@ -168,24 +179,11 @@ def extract_lambda_versions(versions: list[dict[str, str]]) -> list[tuple[str, s
     return version_tuples
 
 
-def get_s3_client() -> S3Client:
-    if os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_KEY") and os.getenv("AWS_ENDPOINT_URL"):
-        session = boto3.session.Session(
-            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.getenv("AWS_SECRET_KEY"),
-        )
-        return session.client("s3", endpoint_url=os.getenv("AWS_ENDPOINT_URL"))
-
-    session = boto3.session.Session()
-    return session.client("s3")
-
-
 @with_lambda_profiler()
 @rollbar.lambda_function
 def handler(event, context):
     logger.info("Received event")
 
-    s3_client = get_s3_client()
     batch_item_failures = []
 
     for message_id, message in all_messages(event):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,14 @@
 import copy
 import json
-import os
 import tarfile
 from unittest.mock import Mock, PropertyMock, patch
 
-# Mock required environment variables before importing the lambda module,
-# as it reads them at import time via os.environ[...]
-os.environ.setdefault("MARKLOGIC_HOST", "test-marklogic-host")
-os.environ.setdefault("MARKLOGIC_USER", "test-user")
-os.environ.setdefault("MARKLOGIC_PASSWORD", "test-password")
-os.environ.setdefault("PRIVATE_ASSET_BUCKET", "test-private-bucket")
-os.environ.setdefault("PUBLIC_ASSET_BUCKET", "test-public-bucket")
-os.environ.setdefault("NOTIFY_API_KEY", "test-notify-key")
+from caselawclient.types import DocumentURIString
+from pytest import fixture
 
-from caselawclient.types import DocumentURIString  # noqa: E402
-from pytest import fixture  # noqa: E402
+from src.ds_caselaw_ingester import ingester, lambda_function
 
-from src.ds_caselaw_ingester import ingester, lambda_function  # noqa: E402
-
-from .helpers import create_fake_bulk_file, create_fake_tdr_file  # noqa: E402
+from .helpers import create_fake_bulk_file, create_fake_tdr_file
 
 
 def setup_api_client():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,7 +38,7 @@ NULL_UPDATE_METADATA = '{\n  "Judgment-Update": null,\n  "Judgment-Update-Type":
 
 class TestHandler:
     @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
@@ -62,11 +62,11 @@ class TestHandler:
         annotation,
         notify_new,
         notify_update,
-        boto_session,
+        mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
     ):
-        boto_session.return_value.client.return_value.download_file = create_fake_tdr_file
+        mock_s3_client.download_file = create_fake_tdr_file
         doc = apiclient.get_document_by_uri.return_value
         doc.neutral_citation = None
         mock_doc.return_value = doc
@@ -95,7 +95,7 @@ class TestHandler:
         doc.identifiers.save.assert_not_called()
 
     @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
@@ -121,12 +121,12 @@ class TestHandler:
         annotation,
         notify_new,
         notify_updated,
-        boto_session,
+        mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
     ):
         """Test that, with appropriate stubs, an S3 message passes through the parsing process"""
-        boto_session.return_value.client.return_value.download_file = create_fake_bulk_file
+        mock_s3_client.download_file = create_fake_bulk_file
         mock_uuid4.return_value = "a1b2-c3d4"
         doc = apiclient.get_document_by_uri.return_value
         doc.neutral_citation = "[2012] UKUT 82 (IAC)"
@@ -159,7 +159,7 @@ class TestHandler:
         doc.save_identifiers.assert_called()
 
     @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
@@ -178,11 +178,11 @@ class TestHandler:
         annotation,
         notify_new,
         notify_update,
-        boto_session,
+        mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
     ):
-        boto_session.return_value.client.return_value.download_file = create_fake_error_file
+        mock_s3_client.download_file = create_fake_error_file
         mock_doc.return_value = apiclient.get_document_by_uri.return_value
 
         message = error_message_raw
@@ -221,7 +221,7 @@ class TestHandler:
         mock_doc.identifiers.add.assert_not_called()
         mock_doc.identifiers.save.assert_not_called()
 
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch(
         "src.ds_caselaw_ingester.lambda_function.perform_ingest",
         side_effect=[
@@ -239,7 +239,7 @@ class TestHandler:
         mock_rollbar_call,
         mock_ingest,
         mock_perform_ingest,
-        boto_session,
+        mock_s3_client,
         caplog,
     ):
         message = s3_message_raw

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,7 +37,7 @@ NULL_UPDATE_METADATA = '{\n  "Judgment-Update": null,\n  "Judgment-Update-Type":
 
 
 class TestHandler:
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
@@ -67,7 +67,7 @@ class TestHandler:
         caplog: pytest.LogCaptureFixture,
     ):
         boto_session.return_value.client.return_value.download_file = create_fake_tdr_file
-        doc = apiclient.return_value.get_document_by_uri.return_value
+        doc = apiclient.get_document_by_uri.return_value
         doc.neutral_citation = None
         mock_doc.return_value = doc
 
@@ -94,7 +94,7 @@ class TestHandler:
         doc.identifiers.add.assert_not_called()
         doc.identifiers.save.assert_not_called()
 
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
@@ -128,7 +128,7 @@ class TestHandler:
         """Test that, with appropriate stubs, an S3 message passes through the parsing process"""
         boto_session.return_value.client.return_value.download_file = create_fake_bulk_file
         mock_uuid4.return_value = "a1b2-c3d4"
-        doc = apiclient.return_value.get_document_by_uri.return_value
+        doc = apiclient.get_document_by_uri.return_value
         doc.neutral_citation = "[2012] UKUT 82 (IAC)"
         mock_doc.return_value = doc
 
@@ -158,7 +158,7 @@ class TestHandler:
         assert type(doc.identifiers.add.call_args_list[0].args[0]) is NeutralCitationNumber
         doc.save_identifiers.assert_called()
 
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
@@ -183,7 +183,7 @@ class TestHandler:
         caplog: pytest.LogCaptureFixture,
     ):
         boto_session.return_value.client.return_value.download_file = create_fake_error_file
-        mock_doc.return_value = apiclient.return_value.get_document_by_uri.return_value
+        mock_doc.return_value = apiclient.get_document_by_uri.return_value
 
         message = error_message_raw
 
@@ -232,7 +232,7 @@ class TestHandler:
     )
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
     @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     def test_handler_exception_handled(
         self,
         mock_api_client,
@@ -550,14 +550,7 @@ class TestLambda:
         assert call.args[3] == "v2-a1b2-c3d4.docx"
 
     def test_user_agent(self):
-        """The handler must construct the MarklogicApiClient with an 'ingester' User-Agent."""
-        with (
-            patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient") as mock_client,
-            patch("src.ds_caselaw_ingester.lambda_function.all_messages", return_value=[]),
-        ):
-            lambda_function.handler(event={"Records": []}, context=None)
-        kwargs = mock_client.call_args.kwargs
-        assert "ingester" in kwargs["user_agent"]
+        assert "ingester" in lambda_function.api_client.session.headers["User-Agent"]
 
     @patch("os.path.exists", return_value=True)
     @patch("os.getenv", return_value="")

--- a/tests/test_sqs_handler.py
+++ b/tests/test_sqs_handler.py
@@ -19,7 +19,7 @@ from .helpers import (
 class TestSQSHandler:
     """Tests for SQS event handling (SNS → SQS → Lambda path)."""
 
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
@@ -50,7 +50,7 @@ class TestSQSHandler:
     ):
         """Test that a V2 message arriving via SQS is processed correctly."""
         boto_session.return_value.client.return_value.download_file = create_fake_tdr_file
-        doc = apiclient.return_value.get_document_by_uri.return_value
+        doc = apiclient.get_document_by_uri.return_value
         doc.neutral_citation = None
         mock_doc.return_value = doc
 
@@ -62,7 +62,7 @@ class TestSQSHandler:
         # No failures → empty batchItemFailures
         assert result == {"batchItemFailures": []}
 
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
@@ -96,7 +96,7 @@ class TestSQSHandler:
         """Test that an S3 message arriving via SQS is processed correctly."""
         boto_session.return_value.client.return_value.download_file = create_fake_bulk_file
         mock_uuid4.return_value = "a1b2-c3d4"
-        doc = apiclient.return_value.get_document_by_uri.return_value
+        doc = apiclient.get_document_by_uri.return_value
         doc.neutral_citation = "[2012] UKUT 82 (IAC)"
         mock_doc.return_value = doc
 
@@ -114,7 +114,7 @@ class TestSQSHandler:
     )
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
     @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     def test_sqs_handler_returns_batch_item_failures(
         self,
         mock_api_client,
@@ -139,7 +139,7 @@ class TestSQSHandler:
     )
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
     @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     def test_sqs_handler_partial_batch_failure(
         self,
         mock_api_client,
@@ -181,7 +181,7 @@ class TestSQSHandler:
     )
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
     @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.MarklogicApiClient", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
     def test_sns_handler_still_works(
         self,
         mock_api_client,

--- a/tests/test_sqs_handler.py
+++ b/tests/test_sqs_handler.py
@@ -20,7 +20,7 @@ class TestSQSHandler:
     """Tests for SQS event handling (SNS → SQS → Lambda path)."""
 
     @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
@@ -44,12 +44,12 @@ class TestSQSHandler:
         annotation,
         notify_new,
         notify_update,
-        boto_session,
+        mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
     ):
         """Test that a V2 message arriving via SQS is processed correctly."""
-        boto_session.return_value.client.return_value.download_file = create_fake_tdr_file
+        mock_s3_client.download_file = create_fake_tdr_file
         doc = apiclient.get_document_by_uri.return_value
         doc.neutral_citation = None
         mock_doc.return_value = doc
@@ -63,7 +63,7 @@ class TestSQSHandler:
         assert result == {"batchItemFailures": []}
 
     @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
     @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
     @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
@@ -89,12 +89,12 @@ class TestSQSHandler:
         annotation,
         notify_new,
         notify_updated,
-        boto_session,
+        mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
     ):
         """Test that an S3 message arriving via SQS is processed correctly."""
-        boto_session.return_value.client.return_value.download_file = create_fake_bulk_file
+        mock_s3_client.download_file = create_fake_bulk_file
         mock_uuid4.return_value = "a1b2-c3d4"
         doc = apiclient.get_document_by_uri.return_value
         doc.neutral_citation = "[2012] UKUT 82 (IAC)"
@@ -107,7 +107,7 @@ class TestSQSHandler:
 
         assert result == {"batchItemFailures": []}
 
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch(
         "src.ds_caselaw_ingester.lambda_function.perform_ingest",
         side_effect=exceptions.FileNotFoundException("test-sqs-failure"),
@@ -121,7 +121,7 @@ class TestSQSHandler:
         mock_rollbar_call,
         mock_ingest,
         mock_perform_ingest,
-        boto_session,
+        mock_s3_client,
     ):
         """Failed SQS messages are reported as batchItemFailures so only they are retried."""
         result = lambda_function.handler(event=sqs_v2_event, context=None)
@@ -129,7 +129,7 @@ class TestSQSHandler:
         mock_rollbar_call.assert_called_with(level="error")
         assert result == {"batchItemFailures": [{"itemIdentifier": "msg-001"}]}
 
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch(
         "src.ds_caselaw_ingester.lambda_function.perform_ingest",
         side_effect=[
@@ -146,7 +146,7 @@ class TestSQSHandler:
         mock_rollbar_call,
         mock_ingest,
         mock_perform_ingest,
-        boto_session,
+        mock_s3_client,
     ):
         """When one message in a batch fails, only that message is reported as failed."""
         two_message_sqs_event = {
@@ -174,7 +174,7 @@ class TestSQSHandler:
 
         assert result == {"batchItemFailures": [{"itemIdentifier": "msg-fail"}]}
 
-    @patch("src.ds_caselaw_ingester.lambda_function.boto3.session.Session")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
     @patch(
         "src.ds_caselaw_ingester.lambda_function.perform_ingest",
         side_effect=exceptions.FileNotFoundException("test-sns-still-works"),
@@ -188,7 +188,7 @@ class TestSQSHandler:
         mock_rollbar_call,
         mock_ingest,
         mock_perform_ingest,
-        boto_session,
+        mock_s3_client,
     ):
         """Direct SNS events still work (backward compatibility)."""
         message = v2_message_raw


### PR DESCRIPTION
Moving MarkLogic client into the handler didn't solve our memory leak as predicted, so we're moving it back outside of the handler to reduce object churn when the lambda is kept warm during batch operations.

In a similar change, we're moving the S3 client outside of the handler to reduce object and connection pool churn.

- [x] Move MarkLogic client
- [x] Move S3 client