### PR TITLE
WIP | Feat/cloudwatch alarms with slack integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,8 @@ jobs:
       TF_BACKEND_BUCKET: ${{ secrets.TF_BACKEND_BUCKET }}
       TF_VAR_TRE_MESSAGE_TOPIC_ARN: ${{ secrets.TF_VAR_TRE_MESSAGE_TOPIC_ARN }}
       TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN: ${{ secrets.TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN }}
+      TF_VAR_SLACK_CHANNEL_ID: ${{ secrets.TF_VAR_SLACK_CHANNEL_ID }}
+      TF_VAR_LAMBDA_FUNCTION_NAME: ${{ secrets.TF_VAR_LAMBDA_FUNCTION_NAME }}
 
   build-deploy:
     needs: [set-env, terraform]

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,6 +25,12 @@ on:
       TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN:
         description: "SNS topic ARN that fans out raw S3 ObjectCreated:* event notifications"
         required: true
+      TF_VAR_SLACK_CHANNEL_ID:
+        description: "Slack channel ID (e.g. C0123456789) that receives CloudWatch alarm notifications"
+        required: true
+      TF_VAR_LAMBDA_FUNCTION_NAME:
+        description: "Existing AWS Lambda function name (the auto-generated SAM name, e.g. ds-caselaw-ingester-TNACaselawIngesterFunction-XXXXXX). Used as the FunctionName dimension for CloudWatch alarms."
+        required: true
     outputs:
       ingest_queue_arn:
         description: "ARN of the SQS ingest queue"
@@ -66,6 +72,8 @@ jobs:
       TF_VAR_environment: ${{ inputs.environment }}
       TF_VAR_tre_message_topic_arn: ${{ secrets.TF_VAR_TRE_MESSAGE_TOPIC_ARN }}
       TF_VAR_bulk_ingest_s3_event_topic_arn: ${{ secrets.TF_VAR_BULK_INGEST_S3_EVENT_TOPIC_ARN }}
+      TF_VAR_slack_channel_id: ${{ secrets.TF_VAR_SLACK_CHANNEL_ID }}
+      TF_VAR_lambda_function_name: ${{ secrets.TF_VAR_LAMBDA_FUNCTION_NAME }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -1,0 +1,273 @@
+# CloudWatch alarms for resources managed by this Terraform stack.
+#
+# Following AWS recommended best-practice alarms:
+# https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html
+#
+# Scope of this file:
+#   - SQS ingest queue + DLQ (managed here via the da-terraform-modules/sqs module)
+#   - Ingester Lambda (the function itself is provisioned by SAM in
+#     `template.yml`, but its alarms are owned here. The function name is
+#     pinned in SAM and passed in via `var.lambda_function_name`.)
+#
+# The shared SQS module already creates the following alarms for us, so they are
+# intentionally NOT redefined here:
+#   - <queue>-messages-visible-alarm           (ApproximateNumberOfMessagesVisible on main queue)
+#   - <queue>-dlq-messages-visible-alarm       (ApproximateNumberOfMessagesVisible on DLQ)
+#   - <queue>-dlq-new-messages-added-alarm     (DIFF on DLQ visible+not-visible)
+#   - <queue>-unprocessed-messages-alert       (messages present but none being received)
+#
+# The alarms below cover the remaining AWS-recommended SQS and Lambda alarms,
+# matching the actions_enabled=false / empty-actions style used elsewhere in
+# this account until SNS wiring is added.
+#
+# Follow-up (SQS): the three SQS alarms defined here (oldest-message-age on
+# the main queue and DLQ, plus messages-sent on the DLQ) are AWS-recommended
+# best-practice alarms that every consumer of the shared SQS module would
+# benefit from. Consider upstreaming them into
+# `nationalarchives/da-terraform-modules//sqs` so they're created
+# automatically alongside the existing module-managed alarms, and this file
+# can drop the SQS section entirely.
+#
+# Follow-up (Lambda): migrate the Lambda itself from SAM (`template.yml`)
+# into this Terraform stack so the function and its alarms are co-located.
+
+locals {
+  ingest_queue_name     = "${var.environment}-caselaw-ingest-queue"
+  ingest_queue_dlq_name = "${local.ingest_queue_name}-dlq"
+}
+
+# ApproximateAgeOfOldestMessage — main ingest queue.
+#
+# This alarm helps to detect when consumers are not processing messages from
+# the queue fast enough (e.g. Lambda is throttled, failing, or downstream
+# MarkLogic is slow). A growing oldest-message age is the canonical SQS
+# back-pressure signal.
+#
+# Threshold rationale: the Lambda timeout is 420s and visibility timeout is
+# 2520s (6× Lambda). If a message has been sitting visible for longer than the
+# Lambda timeout, processing is almost certainly falling behind.
+resource "aws_cloudwatch_metric_alarm" "ingest_queue_oldest_message_age" {
+  alarm_name        = "${local.ingest_queue_name}-oldest-message-age-alarm"
+  alarm_description = "Triggers when the oldest message in the ingest queue has been waiting longer than expected. Indicates the Lambda consumer is falling behind (throttled, failing, or downstream slow). Investigate Lambda errors/throttles and downstream (MarkLogic) latency."
+
+  actions_enabled           = false
+  treat_missing_data        = "notBreaching"
+  ok_actions                = []
+  alarm_actions             = []
+  insufficient_data_actions = []
+
+  namespace   = "AWS/SQS"
+  metric_name = "ApproximateAgeOfOldestMessage"
+  statistic   = "Maximum"
+  dimensions = {
+    QueueName = local.ingest_queue_name
+  }
+
+  period              = 60
+  evaluation_periods  = var.ingest_queue_oldest_message_age_evaluation_periods
+  datapoints_to_alarm = var.ingest_queue_oldest_message_age_evaluation_periods
+  threshold           = var.ingest_queue_oldest_message_age_threshold_seconds
+  comparison_operator = "GreaterThanThreshold"
+}
+
+# ApproximateAgeOfOldestMessage — DLQ.
+#
+# AWS recommends alarming on DLQ oldest-message age so failed messages don't
+# silently age out of the 14-day retention window without being investigated.
+resource "aws_cloudwatch_metric_alarm" "ingest_queue_dlq_oldest_message_age" {
+  alarm_name        = "${local.ingest_queue_dlq_name}-oldest-message-age-alarm"
+  alarm_description = "Triggers when a message has been sitting in the ingest DLQ for longer than expected. DLQ messages indicate failed ingestions that need manual review before they age out of retention (14 days)."
+
+  actions_enabled           = false
+  treat_missing_data        = "notBreaching"
+  ok_actions                = []
+  alarm_actions             = []
+  insufficient_data_actions = []
+
+  namespace   = "AWS/SQS"
+  metric_name = "ApproximateAgeOfOldestMessage"
+  statistic   = "Maximum"
+  dimensions = {
+    QueueName = local.ingest_queue_dlq_name
+  }
+
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = var.ingest_queue_dlq_oldest_message_age_threshold_seconds
+  comparison_operator = "GreaterThanThreshold"
+}
+
+# NumberOfMessagesSent — DLQ.
+#
+# AWS recommends alarming on any send to the DLQ so that even a single failed
+# message is surfaced promptly. The module's `new_messages_added_to_dlq_alert`
+# uses a DIFF expression which can miss cases where a message arrives and is
+# immediately re-driven; this alarm provides direct coverage.
+resource "aws_cloudwatch_metric_alarm" "ingest_queue_dlq_messages_sent" {
+  alarm_name        = "${local.ingest_queue_dlq_name}-messages-sent-alarm"
+  alarm_description = "Triggers when one or more messages are sent to the ingest DLQ within the evaluation period. Any DLQ delivery indicates an ingestion failure that exhausted retries."
+
+  actions_enabled           = false
+  treat_missing_data        = "notBreaching"
+  ok_actions                = []
+  alarm_actions             = []
+  insufficient_data_actions = []
+
+  namespace   = "AWS/SQS"
+  metric_name = "NumberOfMessagesSent"
+  statistic   = "Sum"
+  dimensions = {
+    QueueName = local.ingest_queue_dlq_name
+  }
+
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+}
+
+# -----------------------------------------------------------------------------
+# Lambda alarms (function provisioned by SAM, alarms owned here).
+# AWS recommended alarms:
+# https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Lambda
+# -----------------------------------------------------------------------------
+
+locals {
+  # If a reserved concurrency is configured, scale the per-function concurrency
+  # alarm against it; otherwise fall back to the account/region limit.
+  lambda_concurrency_alarm_threshold = var.lambda_reserved_concurrency > 0 ? (
+    0.9 * var.lambda_reserved_concurrency
+    ) : (
+    0.9 * var.region_level_concurrency_limit
+  )
+}
+
+# Errors — any function error indicates an ingestion failure.
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  alarm_name        = "${var.lambda_function_name}-errors-alarm"
+  alarm_description = "Triggers when the ingester Lambda reports any errors. Each error corresponds to a failed ingestion that will be retried via SQS and may end up in the DLQ. Investigate Lambda logs and Rollbar."
+
+  actions_enabled           = false
+  treat_missing_data        = "notBreaching"
+  ok_actions                = []
+  alarm_actions             = []
+  insufficient_data_actions = []
+
+  namespace   = "AWS/Lambda"
+  metric_name = "Errors"
+  statistic   = "Sum"
+  dimensions = {
+    FunctionName = var.lambda_function_name
+  }
+
+  period              = 60
+  evaluation_periods  = 5
+  datapoints_to_alarm = 3
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+}
+
+# Throttles — invocations rejected because concurrency limit was hit.
+# With `max_receive_count = 1` on the queue, a throttle goes straight to the DLQ.
+resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  alarm_name        = "${var.lambda_function_name}-throttles-alarm"
+  alarm_description = "Triggers when the ingester Lambda is throttled. Given max_receive_count=1 on the ingest queue, throttled messages go straight to the DLQ. Consider raising MaximumConcurrency or the account concurrency limit."
+
+  actions_enabled           = false
+  treat_missing_data        = "notBreaching"
+  ok_actions                = []
+  alarm_actions             = []
+  insufficient_data_actions = []
+
+  namespace   = "AWS/Lambda"
+  metric_name = "Throttles"
+  statistic   = "Sum"
+  dimensions = {
+    FunctionName = var.lambda_function_name
+  }
+
+  period              = 60
+  evaluation_periods  = 5
+  datapoints_to_alarm = 3
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+}
+
+# Duration — invocation runtime approaching the configured timeout.
+# Threshold is set to 80% of the function timeout (in milliseconds).
+resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
+  alarm_name        = "${var.lambda_function_name}-duration-alarm"
+  alarm_description = "Triggers when the ingester Lambda's p95 duration exceeds 80% of its configured timeout. Indicates risk of timeouts and degraded throughput; investigate downstream (MarkLogic) latency."
+
+  actions_enabled           = false
+  treat_missing_data        = "notBreaching"
+  ok_actions                = []
+  alarm_actions             = []
+  insufficient_data_actions = []
+
+  namespace          = "AWS/Lambda"
+  metric_name        = "Duration"
+  extended_statistic = "p95"
+  dimensions = {
+    FunctionName = var.lambda_function_name
+  }
+
+  period              = 60
+  evaluation_periods  = 15
+  datapoints_to_alarm = 15
+  threshold           = 0.8 * var.lambda_timeout_seconds * 1000
+  comparison_operator = "GreaterThanThreshold"
+}
+
+# ConcurrentExecutions — function approaching its concurrency ceiling.
+resource "aws_cloudwatch_metric_alarm" "lambda_concurrent_executions" {
+  alarm_name        = "${var.lambda_function_name}-concurrent-executions-alarm"
+  alarm_description = "Triggers when the ingester Lambda's concurrent executions approach 90% of its configured ceiling (reserved concurrency if set, otherwise the region-level limit). Throttling becomes likely soon after."
+
+  actions_enabled           = false
+  treat_missing_data        = "notBreaching"
+  ok_actions                = []
+  alarm_actions             = []
+  insufficient_data_actions = []
+
+  namespace   = "AWS/Lambda"
+  metric_name = "ConcurrentExecutions"
+  statistic   = "Maximum"
+  dimensions = {
+    FunctionName = var.lambda_function_name
+  }
+
+  period              = 60
+  evaluation_periods  = 10
+  datapoints_to_alarm = 10
+  threshold           = local.lambda_concurrency_alarm_threshold
+  comparison_operator = "GreaterThanThreshold"
+}
+
+# ClaimedAccountConcurrency — region-wide Lambda concurrency saturation.
+# This is account-scoped (not function-scoped), but is recommended for any
+# account that runs Lambda functions and is included here while the ingester
+# is the primary Lambda workload in this stack.
+resource "aws_cloudwatch_metric_alarm" "lambda_claimed_account_concurrency" {
+  alarm_name        = "${var.environment}-caselaw-ingester-claimed-account-concurrency-alarm"
+  alarm_description = "This alarm helps to monitor if the concurrency of your Lambda functions is approaching the Region-level concurrency limit of your account. A function starts to be throttled if it reaches the concurrency limit. You can take the following actions to avoid throttling. 1) Request a concurrency increase in this Region. 2) Identify and reduce any unused reserved concurrency or provisioned concurrency. 3) Identify performance issues in the functions to improve the speed of processing and therefore improve throughput. 4) Increase the batch size of the functions, so that more messages are processed by each function invocation."
+
+  actions_enabled           = false
+  treat_missing_data        = "notBreaching"
+  ok_actions                = []
+  alarm_actions             = []
+  insufficient_data_actions = []
+
+  namespace   = "AWS/Lambda"
+  metric_name = "ClaimedAccountConcurrency"
+  statistic   = "Maximum"
+  dimensions  = {}
+
+  period              = 60
+  evaluation_periods  = 10
+  datapoints_to_alarm = 10
+  threshold           = 0.9 * var.region_level_concurrency_limit
+  comparison_operator = "GreaterThanThreshold"
+}

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -9,12 +9,12 @@
 #     `template.yml`, but its alarms are owned here. The function name is
 #     pinned in SAM and passed in via `var.lambda_function_name`.)
 #
-# The shared SQS module already creates the following alarms for us, so they are
+# The shared SQS module, as specified in main.tf, already creates the following alarms for us, so they are
 # intentionally NOT redefined here:
 #   - <queue>-messages-visible-alarm           (ApproximateNumberOfMessagesVisible on main queue)
 #   - <queue>-dlq-messages-visible-alarm       (ApproximateNumberOfMessagesVisible on DLQ)
-#   - <queue>-dlq-new-messages-added-alarm     (DIFF on DLQ visible+not-visible)
-#   - <queue>-unprocessed-messages-alert       (messages present but none being received)
+#   - <queue>-dlq-new-messages-added-alarm     (change in total DLQ messages, i.e. diff of ApproximateNumberOfMessagesVisible and ApproximateNumberOfMessagesNotVisible combined)
+#   - <queue>-unprocessed-messages-alert       (ApproximateNumberOfMessagesVisible > 0 but NumberOfMessagesReceived is 0, i.e. messages are waiting but no consumer is polling)
 #
 # The alarms below cover the remaining AWS-recommended SQS and Lambda alarms,
 # matching the actions_enabled=false / empty-actions style used elsewhere in

--- a/terraform/slack_alarms.tf
+++ b/terraform/slack_alarms.tf
@@ -1,0 +1,155 @@
+# Slack delivery for CloudWatch alarms.
+#
+# Pattern adapted from da-ayr-terraform's `eventbridge_alarms` module
+# (https://github.com/nationalarchives/da-ayr-terraform), but kept account-local
+# — there is no shared management/observability account in Caselaw, so the
+# whole pipeline is created inside this stack.
+#
+# Flow:
+#   CloudWatch alarm state change
+#     -> default event bus (automatic; no alarm_actions wiring needed)
+#     -> EventBridge rule (filters to ALARM and OK transitions)
+#     -> EventBridge API destination (HTTPS POST to Slack chat.postMessage)
+#     -> Slack channel
+#
+# The Slack bot token is read from an AWS Secrets Manager secret. The secret is
+# created here as an empty placeholder; populate the value once via the AWS
+# console or a separate out-of-band process so the token isn't stored in
+# Terraform state in plaintext.
+#
+# Required Slack bot scopes: `chat:write` (and the bot must be invited to the
+# target channel).
+
+locals {
+  slack_alarm_states = toset(["ALARM", "OK"])
+}
+
+# Empty placeholder secret. Populate the bot token (raw `xoxb-...` string)
+# via the AWS console after first apply. Subsequent applies will not overwrite
+# the value because we don't manage `aws_secretsmanager_secret_version`.
+resource "aws_secretsmanager_secret" "alarms_slack_token" {
+  name        = "${var.environment}-caselaw-ingester-alarms-slack-token"
+  description = "Slack bot token used by EventBridge to post CloudWatch alarm notifications. Populate manually after first apply."
+
+  tags = var.tags
+}
+
+data "aws_secretsmanager_secret_version" "alarms_slack_token" {
+  secret_id = aws_secretsmanager_secret.alarms_slack_token.id
+}
+
+resource "aws_cloudwatch_event_connection" "slack" {
+  name               = "${var.environment}-caselaw-ingester-alarms-slack"
+  description        = "Authorization header for Slack chat.postMessage (CloudWatch alarm notifications)"
+  authorization_type = "API_KEY"
+
+  auth_parameters {
+    api_key {
+      key   = "Authorization"
+      value = "Bearer ${data.aws_secretsmanager_secret_version.alarms_slack_token.secret_string}"
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_api_destination" "slack" {
+  name                             = "${var.environment}-caselaw-ingester-alarms-slack"
+  description                      = "Slack chat.postMessage endpoint for CloudWatch alarm notifications"
+  invocation_endpoint              = "https://slack.com/api/chat.postMessage"
+  http_method                      = "POST"
+  invocation_rate_limit_per_second = 5
+  connection_arn                   = aws_cloudwatch_event_connection.slack.arn
+}
+
+# IAM role allowing EventBridge to invoke the Slack API destination.
+data "aws_iam_policy_document" "events_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "invoke_slack" {
+  statement {
+    sid       = "InvokeSlackApiDestination"
+    effect    = "Allow"
+    actions   = ["events:InvokeApiDestination"]
+    resources = [aws_cloudwatch_event_api_destination.slack.arn]
+  }
+}
+
+resource "aws_iam_role" "alarms_to_slack" {
+  name               = "${var.environment}-caselaw-ingester-alarms-to-slack"
+  assume_role_policy = data.aws_iam_policy_document.events_assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy" "alarms_to_slack" {
+  name   = "invoke-slack-api-destination"
+  role   = aws_iam_role.alarms_to_slack.id
+  policy = data.aws_iam_policy_document.invoke_slack.json
+}
+
+# Filter on alarm-name prefix so this rule only matches the ingester's alarms,
+# not unrelated alarms that might be added to this account in future.
+resource "aws_cloudwatch_event_rule" "alarm_state_change" {
+  for_each    = local.slack_alarm_states
+  name        = "${var.environment}-caselaw-ingester-alarm-${lower(each.key)}"
+  description = "Forward CloudWatch alarm ${each.key} transitions for the ingester to Slack"
+
+  event_pattern = jsonencode({
+    source        = ["aws.cloudwatch"]
+    "detail-type" = ["CloudWatch Alarm State Change"]
+    detail = {
+      state = {
+        value = [each.key]
+      }
+      alarmName = [
+        # All ingester alarms follow the `<resource-name>-...-alarm` naming
+        # convention used by da-terraform-modules/sqs, so a small set of
+        # prefixes covers every alarm in this stack:
+        #   - `<env>-caselaw-ingest-queue-...`     (main queue: module + ours)
+        #   - `<env>-caselaw-ingest-queue-dlq-...` (DLQ: module + ours)
+        #   - `<lambda-function-name>-...`         (Lambda alarms)
+        #   - `<env>-caselaw-ingester-...`         (account-scoped Lambda alarms)
+        { prefix = "${local.ingest_queue_name}-" },
+        { prefix = "${local.ingest_queue_dlq_name}-" },
+        { prefix = "${var.lambda_function_name}-" },
+        { prefix = "${var.environment}-caselaw-ingester-" },
+      ]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "alarm_state_change_to_slack" {
+  for_each = local.slack_alarm_states
+  rule     = aws_cloudwatch_event_rule.alarm_state_change[each.key].name
+  arn      = aws_cloudwatch_event_api_destination.slack.arn
+  role_arn = aws_iam_role.alarms_to_slack.arn
+
+  input_transformer {
+    input_paths = {
+      alarmName = "$.detail.alarmName"
+      resources = "$.resources[0]"
+      state     = "$.detail.state.value"
+      reason    = "$.detail.state.reason"
+      time      = "$.detail.state.timestamp"
+    }
+
+    # Slack Web API payload. `channel` is the Slack channel ID (NOT the name).
+    input_template = <<-JSON
+      {
+        "channel": "${var.slack_channel_id}",
+        "text": "${each.key == "ALARM" ? ":helmet_with_white_cross:" : ":green-tick:"} *${var.environment} ingester* alarm <alarmName> -> ${each.key}\n*Resource:* <resources>\n*Time:* <time>\n*Reason:* <reason>"
+      }
+    JSON
+  }
+}
+
+# NOTE: alarms intentionally keep `actions_enabled = false`. CloudWatch always
+# emits state-change events to the default EventBridge bus regardless of that
+# flag, so the rule above still fires; setting it true would (incorrectly)
+# also try to fan out to non-existent SNS topics.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,3 +52,74 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+# --- CloudWatch alarm thresholds (see alarms.tf) ---
+
+variable "ingest_queue_oldest_message_age_threshold_seconds" {
+  description = <<-EOT
+    Threshold in seconds for the ingest queue ApproximateAgeOfOldestMessage alarm.
+    Default 600s (10 minutes) — comfortably above the 420s Lambda timeout, so
+    transient single-message slowness doesn't fire, but a real backlog does.
+  EOT
+  type        = number
+  default     = 600
+}
+
+variable "ingest_queue_oldest_message_age_evaluation_periods" {
+  description = "Number of consecutive 1-minute periods the oldest-message-age alarm must breach before firing."
+  type        = number
+  default     = 5
+}
+
+variable "ingest_queue_dlq_oldest_message_age_threshold_seconds" {
+  description = <<-EOT
+    Threshold in seconds for the ingest DLQ ApproximateAgeOfOldestMessage alarm.
+    Default 3600s (1 hour) — DLQ messages should be triaged well before the
+    14-day retention window expires.
+  EOT
+  type        = number
+  default     = 3600
+}
+
+# --- Lambda alarm configuration (see alarms.tf) ---
+#
+# The ingester Lambda itself is currently provisioned by SAM (`template.yml`),
+# but its CloudWatch alarms are owned here. SAM auto-generates the function
+# name as `<sam-stack-name>-TNACaselawIngesterFunction-<hash>` (the hash
+# differs per environment), so the resolved name must be supplied here as a
+# per-environment secret rather than computed from the stack name.
+
+variable "lambda_function_name" {
+  description = <<-EOT
+    Name of the existing ingester Lambda function (used as the `FunctionName`
+    dimension for CloudWatch alarms). Look this up in the AWS console for each
+    environment — SAM auto-generates it as
+    `<sam-stack-name>-TNACaselawIngesterFunction-<hash>` and the hash differs
+    between environments. When the Lambda is migrated from SAM into this
+    Terraform stack, this variable can be removed and replaced with a direct
+    resource reference.
+  EOT
+  type        = string
+}
+
+variable "lambda_timeout_seconds" {
+  description = "The Lambda function's configured timeout. Used to set the Duration alarm threshold (default = 80% of this)."
+  type        = number
+  default     = 420
+}
+
+variable "lambda_reserved_concurrency" {
+  description = <<-EOT
+    Optional reserved concurrency configured for the ingester Lambda. If set
+    (>0), the ConcurrentExecutions alarm fires at 90% of this value. If 0 or
+    null, the alarm is sized against `region_level_concurrency_limit` instead.
+  EOT
+  type        = number
+  default     = 0
+}
+
+variable "region_level_concurrency_limit" {
+  description = "Account+region Lambda unreserved concurrency limit. Used by the ClaimedAccountConcurrency alarm (fires at 90%)."
+  type        = number
+  default     = 1000
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -123,3 +123,20 @@ variable "region_level_concurrency_limit" {
   type        = number
   default     = 1000
 }
+
+# --- Slack alarm delivery (see slack_alarms.tf) ---
+
+variable "slack_channel_id" {
+  description = <<-EOT
+    Slack channel ID (NOT the channel name) that CloudWatch alarm
+    notifications will be posted to via EventBridge -> Slack chat.postMessage.
+    Example: "C0123456789". The bot whose token is stored in the
+    `<env>-caselaw-ingester-alarms-slack-token` Secrets Manager secret must be
+    invited to this channel.
+
+    No default — must be provided per environment (e.g. via tfvars / CI
+    secret) so the channel ID isn't committed to this public repo.
+  EOT
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
FCLC-968

Adds the AWS-recommended CloudWatch alarms for the ingester (SQS + Lambda) and routes their state changes to Slack via an account-local EventBridge → API destination pipeline (same pattern as AYR).

Today the only alarm we have is `MessagesVisible > 0` on the DLQ (created by `da-terraform-modules/sqs`). That leaves us blind to backed-up queues, Lambda errors/throttles, timeouts, and concurrency exhaustion.

### What's in each commit

1. **`feat(terraform): add CloudWatch alarms for SQS and Lambda`**
   - SQS: `ApproximateAgeOfOldestMessage` on main queue + DLQ, `NumberOfMessagesSent` on DLQ.
   - Lambda: `Errors`, `Throttles`, `Duration` (vs. configured timeout), `ConcurrentExecutions` (vs. reserved concurrency), `ClaimedAccountConcurrency` (vs. account/region limit at 90%).
   - Thresholds exposed as variables with sensible defaults.
   - Lambda function name supplied via `var.lambda_function_name` because the function is still SAM-managed.

2. **`feat(terraform): forward CloudWatch alarms to Slack via EventBridge`**
   - Account-local EventBridge rule on `CloudWatch Alarm State Change` events filtered to ingester alarms.
   - API destination + connection posting to Slack `chat.postMessage`.
   - Slack bot token held in an empty Secrets Manager secret (populated manually post-apply, never committed).
   - `slack_channel_id` is a sensitive per-environment variable with no default so it isn't leaked in this public repo.

3. **`ci: pass slack channel ID and Lambda function name to terraform`**
   - Adds `TF_VAR_SLACK_CHANNEL_ID` and `TF_VAR_LAMBDA_FUNCTION_NAME` as required secret inputs on the reusable `terraform.yml` workflow and forwards them from `deploy.yml`.

### Pre-merge actions

- Add `TF_VAR_SLACK_CHANNEL_ID` and `TF_VAR_LAMBDA_FUNCTION_NAME` GitHub secrets per environment (staging + production).
- After first apply, populate the `<env>-caselaw-ingester-alarms-slack-token` Secrets Manager secret with the Slack bot token, and invite the bot to the target channel.

### Follow-ups (not in this PR)

- Upstream the SQS alarms into `da-terraform-modules//sqs` so other consumers benefit.
- Migrate the Lambda from SAM to Terraform so we can drop `var.lambda_function_name`.

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

https://national-archives.atlassian.net/browse/FCLC-1796