### PR TITLE
fix: Remove unnecessary latest-tag job in release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,15 +84,3 @@ jobs:
           VpcSubnetId1=${{ vars.VPC_SUBNET_ID_1 }}
           VpcSubnetId2=${{ vars.VPC_SUBNET_ID_2 }}
           VpcSecurityGroupId=${{ vars.VPC_SECURITY_GROUP_ID }}
-
-  latest-tag:
-    if: github.event_name == 'release'
-    needs: build-deploy
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67 # v1.6.3


### PR DESCRIPTION
fix: Remove unnecessary latest-tag job in release workflow.

It is needed for other repos for deployment but this repo deploys directly with github actions

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

<!-- What Jira ticket does this correspond to? All work should have a ticket (although multiple PRs may share the same one) -->

FCL-
