### PR TITLE
Ensure sqs lambda trigger enabled on sam deployment

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -94,6 +94,7 @@ Resources:
           Properties:
             Queue: !Ref IngestQueueArn
             BatchSize: !Ref IngestQueueBatchSize
+            Enabled: true
             ScalingConfig:
               MaximumConcurrency: !Ref MaximumConcurrency
             FunctionResponseTypes:


### PR DESCRIPTION
I had disabled the sqs trigger in production due to the issues we were facing with it so far but the last prod deploy did not re-enable it by default - added explicit config option to ensure it is always enabled on deploy,

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

<!-- What Jira ticket does this correspond to? All work should have a ticket (although multiple PRs may share the same one) -->

https://national-archives.atlassian.net/browse/FCLC-1796