### PR TITLE
Add CodeGuru profiling and configuration to terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,7 @@ jobs:
           RollbarToken=${{ secrets.ROLLBAR_TOKEN }}
           SnsTopic=${{ vars.SNS_TOPIC }}
           IngestQueueArn=${{ needs.terraform.outputs.ingest_queue_arn }}
+          CodeGuruProfilingGroupArn=${{ needs.terraform.outputs.codeguru_profiling_group_arn }}
           VpcSubnetId0=${{ vars.VPC_SUBNET_ID_0 }}
           VpcSubnetId1=${{ vars.VPC_SUBNET_ID_1 }}
           VpcSubnetId2=${{ vars.VPC_SUBNET_ID_2 }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -29,6 +29,9 @@ on:
       ingest_queue_arn:
         description: "ARN of the SQS ingest queue"
         value: ${{ jobs.terraform.outputs.ingest_queue_arn }}
+      codeguru_profiling_group_arn:
+        description: "ARN of the CodeGuru Profiler profiling group"
+        value: ${{ jobs.terraform.outputs.codeguru_profiling_group_arn }}
   workflow_dispatch:
     inputs:
       environment:
@@ -59,6 +62,7 @@ jobs:
     environment: ${{ inputs.environment }}
     outputs:
       ingest_queue_arn: ${{ steps.tf-outputs.outputs.ingest_queue_arn }}
+      codeguru_profiling_group_arn: ${{ steps.tf-outputs.outputs.codeguru_profiling_group_arn }}
     permissions:
       contents: read
       id-token: write
@@ -107,4 +111,5 @@ jobs:
         id: tf-outputs
         run: |
           echo "ingest_queue_arn=$(terraform output -raw ingest_queue_arn)" >> "$GITHUB_OUTPUT"
+          echo "codeguru_profiling_group_arn=$(terraform output -raw codeguru_profiling_group_arn)" >> "$GITHUB_OUTPUT"
         working-directory: terraform

--- a/template.yml
+++ b/template.yml
@@ -76,6 +76,9 @@ Parameters:
   VpcSecurityGroupId:
     Description: "VPC Security Group ID"
     Type: "String"
+  CodeGuruProfilingGroupArn:
+    Description: "CodeGuru Profiler Group ARN (created by Terraform)"
+    Type: "String"
 
 Resources:
   TNACaselawIngesterFunction:
@@ -115,6 +118,7 @@ Resources:
           ROLLBAR_ENV: !Ref RollbarEnv
           ROLLBAR_TOKEN: !Ref RollbarToken
           SNS_TOPIC: !Ref SnsTopic
+          AWS_CODEGURU_PROFILER_GROUP_ARN: !Ref CodeGuruProfilingGroupArn
       VpcConfig:
         SubnetIds:
           - !Ref VpcSubnetId0
@@ -122,6 +126,14 @@ Resources:
           - !Ref VpcSubnetId2
         SecurityGroupIds:
           - !Ref VpcSecurityGroupId
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - "codeguru-profiler:ConfigureAgent"
+                - "codeguru-profiler:PostAgentProfile"
+              Resource: !Ref CodeGuruProfilingGroupArn
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -104,3 +104,19 @@ resource "aws_sns_topic_subscription" "bulk_ingest_s3_event_subscription" {
     }
   })
 }
+
+# CodeGuru Profiling Group for the ingester Lambda
+resource "aws_codeguruprofiler_profiling_group" "ingester" {
+  name = "${var.environment}-${lower(var.codeguru_profiling_group_name)}"
+
+  compute_platform = "AWSLambda"
+
+  agent_orchestration_config {
+    profiling_enabled = true
+  }
+
+  tags = merge(var.tags, {
+    Environment = var.environment
+    Purpose     = "Profiling for ds-caselaw-ingester Lambda"
+  })
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -22,3 +22,8 @@ output "ingest_queue_alarm_arns" {
   description = "ARNs of the CloudWatch alarms for the ingest queue"
   value       = module.ingest_queue.alarms
 }
+
+output "codeguru_profiling_group_arn" {
+  description = "ARN of the CodeGuru Profiler profiling group for the ingester Lambda"
+  value       = aws_codeguruprofiler_profiling_group.ingester.arn
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,3 +52,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "codeguru_profiling_group_name" {
+  description = "AWS CodeGuru Profiler group name for the Lambda function"
+  type        = string
+  default     = "ingester"
+}


### PR DESCRIPTION
CodeGuru allows us to identify hotspots in the application which are taking an unusual amount of time or CPU. This adds the creation of a profiling group and configuration of the lambda environment to the terraform configuration.

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram
