### PR TITLE
fix: stop marking terraform plans as deployments in github actions

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/terraform.yml
     with:
       environment: ${{ needs.set-env.outputs.environment }}
+      deployment: false
       apply: false
     permissions:
       id-token: write


### PR DESCRIPTION
fix: stop marking terraform plans as deployments in github actions<!-- Describe what has changed in this PR, and why -->

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

