### PR TITLE
Remove redundant resource tag on CodeGuru profile group

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -114,9 +114,4 @@ resource "aws_codeguruprofiler_profiling_group" "ingester" {
   agent_orchestration_config {
     profiling_enabled = true
   }
-
-  tags = merge(var.tags, {
-    Environment = var.environment
-    Purpose     = "Profiling for ds-caselaw-ingester Lambda"
-  })
 }


### PR DESCRIPTION
We don't need this tag and it's stopping terraform deploying things, so remove it.

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram
