### PR TITLE
Increase ingester's max-concurrency to 100 speed up bulk ingestion

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -63,7 +63,7 @@ Parameters:
   MaximumConcurrency:
     Description: "Maximum concurrent Lambda invocations from the SQS event source"
     Type: "Number"
-    Default: 5
+    Default: 100
   VpcSubnetId0:
     Description: "VPC Subnet ID 0"
     Type: "String"


### PR DESCRIPTION
Increase ingester's max-concurrency to 100 speed up bulk ingestion

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

<!-- What Jira ticket does this correspond to? All work should have a ticket (although multiple PRs may share the same one) -->

FCL-
