### PR TITLE
Revert api client back to 45.0.0 due to broken and yanked 45.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
           - types-python-dateutil==2.9.0.20260408
           - types-pytz==2026.1.1.20260408
           - boto3-stubs[s3,sns]==1.43.2
-          - ds-caselaw-marklogic-api-client==45.1.0
+          - ds-caselaw-marklogic-api-client==45.0.0
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client==45.1.0
+ds-caselaw-marklogic-api-client==45.0.0
 requests-toolbelt~=1.0
 urllib3~=2.2
 boto3


### PR DESCRIPTION
Revert api client back to 45.0.0 due to broken and yanked 45.1.0

## Jira

<!-- What Jira ticket does this correspond to? All work should have a ticket (although multiple PRs may share the same one) -->

FCL-
