### PR TITLE
[FCLC-1919] Add types-lxml to mypy config in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
           - types-requests==2.33.0.20260503
           - types-python-dateutil==2.9.0.20260408
           - types-pytz==2026.1.1.20260408
+          - types-lxml==2026.2.16
           - boto3-stubs[s3,sns]==1.43.3
           - ds-caselaw-marklogic-api-client==45.0.0
 


### PR DESCRIPTION
This gives mypy the type stubs needed to identify typing problems when passing XML into the API Client.


## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

FCLC-1919
