### PR TITLE
chore: Update API client to 46.1.1 and fix breaking XML API change (XML -> lxml)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
           - types-pytz==2026.2.0.20260506
           - types-lxml==2026.2.16
           - boto3-stubs[s3,sns]==1.43.4
-          - ds-caselaw-marklogic-api-client==45.0.0
+          - ds-caselaw-marklogic-api-client==46.1.1
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django-environ~=0.10
-ds-caselaw-marklogic-api-client==45.0.0
+ds-caselaw-marklogic-api-client==46.1.1
 requests-toolbelt~=1.0
 urllib3~=2.2
 boto3

--- a/src/ds_caselaw_ingester/ingester.py
+++ b/src/ds_caselaw_ingester/ingester.py
@@ -4,13 +4,13 @@ import json
 import logging
 import os
 import tarfile
-import xml.etree.ElementTree as ET
 from contextlib import suppress
 from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any, TypedDict
 from uuid import uuid4
 from xml.sax.saxutils import escape
 
+import lxml.etree as ET
 from botocore.exceptions import NoCredentialsError
 from caselawclient.Client import MarklogicApiClient
 from caselawclient.client_helpers import get_document_type_class
@@ -25,6 +25,7 @@ from caselawclient.models.parser_logs import ParserLog
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities.aws import S3PrefixString
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue
+from caselawclient.xml_helpers import Element
 from mypy_boto3_s3.client import S3Client
 from notifications_python_client.notifications import NotificationsAPIClient
 
@@ -129,12 +130,6 @@ def extract_xml_file(tar: tarfile.TarFile, xml_file_name: str) -> IO[bytes] | No
     return xml_file
 
 
-def parse_xml(xml: bytes) -> ET.Element:
-    ET.register_namespace("", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0")
-    ET.register_namespace("uk", "https://caselaw.nationalarchives.gov.uk/akn")
-    return ET.XML(xml)
-
-
 def create_parser_log_xml(tar: tarfile.TarFile) -> bytes:
     parser_log_value = "<error>parser.log not found</error>"
     for member in tar.getmembers():
@@ -148,26 +143,24 @@ def create_parser_log_xml(tar: tarfile.TarFile) -> bytes:
     return parser_log_value.encode("utf-8")
 
 
-def get_best_xml(tar: tarfile.TarFile, xml_file_name: str, consignment_reference: str) -> ET.Element:
+def get_best_xml(tar: tarfile.TarFile, xml_file_name: str, consignment_reference: str) -> Element:
     xml_file = extract_xml_file(tar, xml_file_name)
     if xml_file:
         contents = xml_file.read()
         try:
-            return parse_xml(contents)
+            return ET.fromstring(contents)
         except ET.ParseError:
             logger.warning(
                 "Invalid XML file for consignment reference: %s. Falling back to parser.log contents.",
                 consignment_reference,
             )
-            contents = create_parser_log_xml(tar)
-            return parse_xml(contents)
     else:
         logger.warning(
             "No XML file found in tarfile. consignment reference: %s. Falling back to parser.log contents.",
             consignment_reference,
         )
-        contents = create_parser_log_xml(tar)
-        return parse_xml(contents)
+    contents = create_parser_log_xml(tar)
+    return ET.fromstring(contents)
 
 
 def _build_version_annotation_payload_from_metadata(metadata: TREMetadataDict) -> VersionPayloadDict:

--- a/tests/test_ingester_methods.py
+++ b/tests/test_ingester_methods.py
@@ -1,14 +1,15 @@
 import logging
 import os
 import tarfile
-import xml.etree.ElementTree as ET
 from unittest.mock import ANY, MagicMock, patch
 
 import boto3
+import lxml.etree as ET
 import pytest
 from botocore.exceptions import NoCredentialsError
 from caselawclient.models.documents.exceptions import CannotPublishUnpublishableDocument
 from caselawclient.models.utilities.aws import S3PrefixString
+from caselawclient.xml_helpers import Element
 
 from src.ds_caselaw_ingester import exceptions, ingester
 from src.ds_caselaw_ingester.exceptions import IngestionError
@@ -163,7 +164,7 @@ class TestIngesterGetBestXMLMethod:
             mode="r",
         ) as tar:
             result = ingester.get_best_xml(tar, filename, "a_consignment_reference")
-            assert result.__class__ == ET.Element
+            assert result.__class__ == Element
             assert result.tag == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
 
     def test_get_best_xml_with_invalid_xml_file(self):
@@ -173,7 +174,7 @@ class TestIngesterGetBestXMLMethod:
             mode="r",
         ) as tar:
             result = ingester.get_best_xml(tar, filename, "a_consignment_reference")
-            assert result.__class__ == ET.Element
+            assert result.__class__ == Element
             assert result.tag == "error"
 
     def test_get_best_xml_with_failure_uri_but_valid_xml(self):
@@ -187,7 +188,7 @@ class TestIngesterGetBestXMLMethod:
                 filename,
                 "a_consignment_reference",
             )
-            assert result.__class__ == ET.Element
+            assert result.__class__ == Element
             assert result.tag == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
 
     def test_get_best_xml_with_failure_uri_and_missing_xml(self):
@@ -201,7 +202,7 @@ class TestIngesterGetBestXMLMethod:
                 filename,
                 "a_consignment_reference",
             )
-            assert result.__class__ == ET.Element
+            assert result.__class__ == Element
             assert result.tag == "error"
 
     def test_get_best_xml_with_no_xml_file(self):
@@ -215,7 +216,7 @@ class TestIngesterGetBestXMLMethod:
                 filename,
                 "a_consignment_reference",
             )
-            assert result.__class__ == ET.Element
+            assert result.__class__ == Element
             assert result.tag == "error"
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,9 +2,9 @@ import copy
 import json
 import logging
 import os
-import xml.etree.ElementTree as ET
 from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
 
+import lxml.etree as ET
 import pytest
 import rollbar
 from caselawclient.Client import (


### PR DESCRIPTION
## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram
