### PR TITLE
Update renovate.json to force Renovate cache flush

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
+  "extends": [
+    "github>nationalarchives/ds-find-caselaw-docs",
+    ":pinDependencies"
+  ],
   "pip_requirements": {
     "managerFilePatterns": ["/requirements/.*\\.txt/"]
   }


### PR DESCRIPTION
Renovate isn't correctly applying our latest configuration; attempt to force a flush of its cache by updating renovate.json.