### PR TITLE
Pin all dependencies to exact versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          persist-credentials: false
         env:
           SKIP: no-commit-to-branch
   test:

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>nationalarchives/ds-find-caselaw-docs",
-    ":pinDependencies"
-  ],
+  "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
   "pip_requirements": {
     "managerFilePatterns": ["/requirements/.*\\.txt/"]
   }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,12 +1,12 @@
-django-environ~=0.10
+django-environ==0.13.0
 ds-caselaw-marklogic-api-client==46.1.1
-requests-toolbelt~=1.0
-urllib3~=2.2
-boto3
-rollbar
-notifications-python-client~=10.0
+requests-toolbelt==1.0.0
+urllib3==2.7.0
+boto3==1.43.6
+rollbar==1.3.0
+notifications-python-client==10.0.1
 codeguru_profiler_agent==1.2.6
 
-mypy-boto3-s3
-mypy-boto3-sns
-python-dotenv
+mypy-boto3-s3==1.43.5
+mypy-boto3-sns==1.43.0
+python-dotenv==1.2.2


### PR DESCRIPTION
This gives us a more readily reproducible environment, as well as letting Renovate manage our dependencies properly.