### PR TITLE
[FLCL-1888] Store parser run UUID in MarkLogic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
           - types-lxml==2026.2.16
           - boto3-stubs[s3,sns]==1.43.6
           - ds-caselaw-marklogic-api-client==46.1.1
+          - ds-caselaw-utils==4.3.1
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 django-environ==0.13.0
 ds-caselaw-marklogic-api-client==46.1.1
+ds-caselaw-utils==4.3.1
 requests-toolbelt==1.0.0
 urllib3==2.7.0
 boto3==1.43.6

--- a/src/ds_caselaw_ingester/ingester.py
+++ b/src/ds_caselaw_ingester/ingester.py
@@ -26,7 +26,7 @@ from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities.aws import S3PrefixString
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue
 from caselawclient.xml_helpers import Element
-from ds_caselaw_utils.types.metadata_schema_autogen import DocumentProcessingMetadata
+from ds_caselaw_utils.types.metadata_schema_autogen import DocumentProcessingMetadata, ParserProcessMetadata
 from mypy_boto3_s3.client import S3Client
 from notifications_python_client.notifications import NotificationsAPIClient
 
@@ -407,6 +407,7 @@ class Ingest:
 
     def store_metadata(self) -> None:
         tdr_metadata = self.metadata["parameters"]["TDR"]
+        parser_metadata: ParserProcessMetadata = self.metadata["parameters"]["PARSER"]
 
         # Store source information
         self.api_client.set_property(
@@ -427,6 +428,14 @@ class Ingest:
             name="transfer-received-at",
             value=tdr_metadata["Consignment-Completed-Datetime"],
         )
+
+        # Set parser metadata
+        if "parser_run_id" in parser_metadata:
+            self.api_client.set_property(
+                self.uri,
+                name="parser-run-id",
+                value=parser_metadata["parser_run_id"],
+            )
 
     def save_files_to_s3(self) -> None:
         # Determine if there's a word document -- we need to know before we save the tar.gz file

--- a/src/ds_caselaw_ingester/ingester.py
+++ b/src/ds_caselaw_ingester/ingester.py
@@ -6,7 +6,7 @@ import os
 import tarfile
 from contextlib import suppress
 from functools import cached_property
-from typing import IO, TYPE_CHECKING, Any, TypedDict
+from typing import IO, TYPE_CHECKING, TypedDict
 from uuid import uuid4
 from xml.sax.saxutils import escape
 
@@ -26,6 +26,7 @@ from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities.aws import S3PrefixString
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue
 from caselawclient.xml_helpers import Element
+from ds_caselaw_utils.types.metadata_schema_autogen import DocumentProcessingMetadata
 from mypy_boto3_s3.client import S3Client
 from notifications_python_client.notifications import NotificationsAPIClient
 
@@ -54,22 +55,18 @@ PRIVATE_ASSET_BUCKET: str = os.environ["PRIVATE_ASSET_BUCKET"]
 PUBLIC_ASSET_BUCKET: str = os.environ["PUBLIC_ASSET_BUCKET"]
 
 
-class TREMetadataDict(TypedDict):
-    parameters: dict[str, Any]
-
-
 class SubmitterInformationDict(TypedDict):
     name: str
     email: str
 
 
 class VersionPayloadDict(TypedDict, total=False):
-    tre_raw_metadata: TREMetadataDict
+    tre_raw_metadata: DocumentProcessingMetadata
     tdr_reference: str
     submitter: SubmitterInformationDict
 
 
-def extract_metadata(tar: tarfile.TarFile, consignment_reference: str) -> TREMetadataDict:
+def extract_metadata(tar: tarfile.TarFile, consignment_reference: str) -> DocumentProcessingMetadata:
     te_metadata_file = None
     decoder = json.decoder.JSONDecoder()
     for member in tar.getmembers():
@@ -163,7 +160,7 @@ def get_best_xml(tar: tarfile.TarFile, xml_file_name: str, consignment_reference
     return ET.fromstring(contents)
 
 
-def _build_version_annotation_payload_from_metadata(metadata: TREMetadataDict) -> VersionPayloadDict:
+def _build_version_annotation_payload_from_metadata(metadata: DocumentProcessingMetadata) -> VersionPayloadDict:
     """Turns metadata from TRE into a structured annotation payload."""
     payload: VersionPayloadDict = {
         "tre_raw_metadata": metadata,
@@ -179,7 +176,7 @@ def _build_version_annotation_payload_from_metadata(metadata: TREMetadataDict) -
     return payload
 
 
-def personalise_email(uri: str, metadata: TREMetadataDict) -> dict:
+def personalise_email(uri: str, metadata: DocumentProcessingMetadata) -> dict:
     """Doesn't contain 'doctype', re-add for new judgment notification"""
     try:
         tdr_metadata = metadata["parameters"]["TDR"]
@@ -207,7 +204,7 @@ def personalise_email(uri: str, metadata: TREMetadataDict) -> dict:
     }
 
 
-def extract_source_filename(metadata: TREMetadataDict, consignment_reference: str) -> str:
+def extract_source_filename(metadata: DocumentProcessingMetadata, consignment_reference: str) -> str:
     try:
         return metadata["parameters"]["TRE"]["payload"]["filename"]
     except KeyError as err:
@@ -227,7 +224,7 @@ def modify_filename(original: str, addition: str) -> str:
 
 
 class Metadata:
-    def __init__(self, metadata: TREMetadataDict) -> None:
+    def __init__(self, metadata: DocumentProcessingMetadata) -> None:
         self.metadata = metadata
         self.parameters = metadata.get("parameters", {})
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,0 +1,247 @@
+import logging
+from unittest.mock import ANY, PropertyMock, call, patch
+
+import pytest
+import rollbar
+from caselawclient.factories import IdentifierResolutionsFactory
+from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
+from caselawclient.types import DocumentURIString
+
+from src.ds_caselaw_ingester import exceptions, lambda_function
+
+from .conftest import error_message_raw, s3_message_raw, v2_message_raw
+from .helpers import (
+    assert_log_does_not_have_message_starting,
+    assert_log_has_message,
+    assert_log_has_message_starting,
+    assert_log_shows_successful_ingest,
+    create_fake_bulk_file,
+    create_fake_error_file,
+    create_fake_tdr_file,
+)
+
+rollbar.init(access_token=None, enabled=False)
+
+
+class TestHandler:
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
+    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
+    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
+    @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
+    @patch("src.ds_caselaw_ingester.ingester.modify_filename")
+    @patch("src.ds_caselaw_ingester.ingester.Document")
+    @patch(
+        "src.ds_caselaw_ingester.ingester.Ingest.find_existing_document_by_ncn",
+        return_value=IdentifierResolutionsFactory.build(),
+    )
+    @patch(
+        "src.ds_caselaw_ingester.ingester.Ingest.database_location",
+        new_callable=PropertyMock,
+        return_value=((DocumentURIString("cat"), True)),
+    )
+    def test_handler_messages_v2_normal(
+        self,
+        mock_database_location,
+        mock_existing_uri,
+        mock_doc,
+        modify_filename,
+        annotation,
+        notify_new,
+        notify_update,
+        mock_s3_client,
+        apiclient,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        mock_s3_client.download_file = create_fake_tdr_file
+        doc = apiclient.get_document_by_uri.return_value
+        doc.neutral_citation = None
+        mock_doc.return_value = doc
+
+        message = v2_message_raw
+        event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
+        lambda_function.handler(event=event, context=None)
+
+        assert_log_shows_successful_ingest(caplog)
+        assert_log_does_not_have_message_starting(caplog, "publishing")
+        assert "image1.png" in caplog.text
+        notify_update.assert_called()
+        assert notify_update.call_count == 2
+        notify_new.assert_not_called()
+        modify_filename.assert_not_called()
+        doc.publish.assert_not_called()
+
+        annotation.assert_called_with(
+            ANY,
+            automated=False,
+            message="Updated document submitted by TDR user",
+            payload=ANY,
+        )
+        assert annotation.call_count == 2
+        doc.identifiers.add.assert_not_called()
+        doc.identifiers.save.assert_not_called()
+
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
+    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
+    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
+    @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
+    @patch("src.ds_caselaw_ingester.ingester.modify_filename")
+    @patch("src.ds_caselaw_ingester.ingester.uuid4")
+    @patch("src.ds_caselaw_ingester.ingester.Document")
+    @patch(
+        "src.ds_caselaw_ingester.ingester.Ingest.find_existing_document_by_ncn",
+        return_value=IdentifierResolutionsFactory.build(),
+    )
+    @patch(
+        "src.ds_caselaw_ingester.ingester.Ingest.database_location",
+        new_callable=PropertyMock,
+        return_value=(DocumentURIString("cat"), True),
+    )
+    def test_handler_messages_s3(
+        self,
+        mock_determine,
+        mock_existing,
+        mock_doc,
+        mock_uuid4,
+        modify_filename,
+        annotation,
+        notify_new,
+        notify_updated,
+        mock_s3_client,
+        apiclient,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Test that, with appropriate stubs, an S3 message passes through the parsing process"""
+        mock_s3_client.download_file = create_fake_bulk_file
+        mock_uuid4.return_value = "a1b2-c3d4"
+        doc = apiclient.get_document_by_uri.return_value
+        doc.neutral_citation = "[2012] UKUT 82 (IAC)"
+        mock_doc.return_value = doc
+
+        message = s3_message_raw
+        event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
+        lambda_function.handler(event=event, context=None)
+
+        assert_log_shows_successful_ingest(caplog)
+
+        assert_log_has_message(caplog, "Ingester Start: Consignment reference BULK-0")
+        assert_log_has_message(caplog, "tar.gz saved locally as /tmp/BULK-0.tar.gz")
+        assert_log_has_message_starting(caplog, "publishing")
+
+        doc.publish.assert_called_with()
+        notify_new.assert_not_called()
+        notify_updated.assert_not_called()
+        modify_filename.assert_not_called()
+
+        annotation.assert_called_with(
+            ANY,
+            automated=True,
+            message="Updated document uploaded by Find Case Law",
+            payload=ANY,
+        )
+        assert annotation.call_count == 2
+        assert doc.identifiers.add.call_args_list[0].args[0].value == "[2012] UKUT 82 (IAC)"
+        assert type(doc.identifiers.add.call_args_list[0].args[0]) is NeutralCitationNumber
+        doc.save_identifiers.assert_called()
+
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
+    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
+    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
+    @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
+    @patch("src.ds_caselaw_ingester.ingester.modify_filename")
+    @patch("src.ds_caselaw_ingester.ingester.Document")
+    @patch(
+        "src.ds_caselaw_ingester.lambda_function.Ingest.database_location",
+        new_callable=PropertyMock,
+        return_value=(DocumentURIString("uuid"), False),
+    )
+    def test_handler_messages_v2_parser_error(
+        self,
+        mock_determine_uri,
+        mock_doc,
+        modify_filename,
+        annotation,
+        notify_new,
+        notify_update,
+        mock_s3_client,
+        apiclient,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        mock_s3_client.download_file = create_fake_error_file
+        mock_doc.return_value = apiclient.get_document_by_uri.return_value
+
+        message = error_message_raw
+
+        event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
+        lambda_function.handler(event=event, context=None)
+
+        assert_log_has_message(caplog, "tar.gz saved locally as /tmp/TDR-2025-CN7V.tar.gz")
+        assert_log_has_message(
+            caplog,
+            "No XML file found in tarfile. consignment reference: TDR-2025-CN7V. Falling back to parser.log contents.",
+            logging.WARNING,
+        )
+        assert_log_has_message(caplog, "Ingesting document uuid")
+        assert_log_has_message(caplog, "Inserted judgment xml for uuid")
+        assert_log_has_message(caplog, "extracted source filename is 'failures_TDR-2025-CN7V.docx'")
+        assert_log_has_message(caplog, "Upload Successful uuid/TDR-2025-CN7V.tar.gz")
+        assert_log_has_message(caplog, "saved tar.gz as '/tmp/TDR-2025-CN7V.tar.gz'")
+        assert_log_has_message(caplog, "Upload Successful uuid/uuid.docx")
+        assert_log_has_message(caplog, "Upload Successful uuid/parser.log")
+        assert_log_has_message(caplog, "Ingestion complete")
+        assert_log_does_not_have_message_starting(caplog, "publishing")
+        notify_new.assert_called()
+        assert notify_new.call_count == 2
+        notify_update.assert_not_called()
+        modify_filename.assert_not_called()
+        mock_doc.publish.assert_not_called()
+
+        annotation.assert_called_with(
+            ANY,
+            automated=False,
+            message="New document uploaded by Find Case Law",
+            payload=ANY,
+        )
+        assert annotation.call_count == 2
+        mock_doc.identifiers.add.assert_not_called()
+        mock_doc.identifiers.save.assert_not_called()
+
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
+    @patch(
+        "src.ds_caselaw_ingester.lambda_function.perform_ingest",
+        side_effect=[
+            exceptions.FileNotFoundException("test"),
+            exceptions.DocxFilenameNotFoundException("test2"),
+            exceptions.CannotPublishException(),
+        ],
+    )
+    @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
+    @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    def test_handler_exception_handled(
+        self,
+        mock_api_client,
+        mock_rollbar_call,
+        mock_ingest,
+        mock_perform_ingest,
+        mock_s3_client,
+        caplog,
+    ):
+        message = s3_message_raw
+        event = {
+            "Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}, {"Sns": {"Message": message}}],
+        }
+        lambda_function.handler(event=event, context=None)
+
+        # rollbar is called each time it fails
+        mock_rollbar_call.assert_has_calls([call(level="error"), call(level="error"), call(level="error")])
+
+        # stacktraces are in the log
+        assert_log_has_message(caplog, "Error processing message", logging.ERROR)
+        assert "Traceback (most recent call last):" in caplog.text
+        assert "ds_caselaw_ingester.exceptions.FileNotFoundException: test" in caplog.text
+
+        # the first invocation does not block the second
+        assert "ds_caselaw_ingester.exceptions.DocxFilenameNotFoundException: test2" in caplog.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -272,6 +272,7 @@ class TestLambda:
                     "Contact-Email": "someone@example.com",
                     "Judgment-Neutral-Citation": "[2019] UKSC 1701",
                 },
+                "PARSER": {"parser_run_id": "607e7ef1-3b5e-431b-b115-bb1811767f5c"},
             },
         }
         v2_ingest.uri = "uri"
@@ -284,6 +285,7 @@ class TestLambda:
             call("uri", name="source-email", value="someone@example.com"),
             call("uri", name="transfer-consignment-reference", value="TDR-2021-CF6L"),
             call("uri", name="transfer-received-at", value="2021-12-16T14:54:06Z"),
+            call("uri", name="parser-run-id", value="607e7ef1-3b5e-431b-b115-bb1811767f5c"),
         ]
         # currently we do not store Judgment-Neutral-Citation directly.
         v2_ingest.api_client.set_property.assert_has_calls(calls)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import logging
 import os
 from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
 
@@ -11,7 +10,6 @@ from caselawclient.Client import (
     MarklogicCommunicationError,
 )
 from caselawclient.factories import IdentifierResolutionFactory, IdentifierResolutionsFactory
-from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.parser_logs import ParserLog
 from caselawclient.models.press_summaries import PressSummary
@@ -20,244 +18,14 @@ from notifications_python_client.notifications import NotificationsAPIClient
 
 from src.ds_caselaw_ingester import exceptions, ingester, lambda_function
 
-from .conftest import error_message_raw, s3_message_raw, v2_message, v2_message_raw
+from .conftest import s3_message_raw, v2_message
 from .helpers import (
-    assert_log_does_not_have_message_starting,
-    assert_log_has_message,
     assert_log_has_message_starting,
-    assert_log_shows_successful_ingest,
-    create_fake_bulk_file,
-    create_fake_error_file,
-    create_fake_tdr_file,
 )
 
 rollbar.init(access_token=None, enabled=False)
 
 NULL_UPDATE_METADATA = '{\n  "Judgment-Update": null,\n  "Judgment-Update-Type": null,\n  "Judgment-Update-Details": null,\n  "Judgment-Neutral-Citation": null,\n  "Judgment-No-Neutral-Citation": null,\n  "Judgment-Reference": null\n}'
-
-
-class TestHandler:
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
-    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
-    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
-    @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
-    @patch("src.ds_caselaw_ingester.ingester.modify_filename")
-    @patch("src.ds_caselaw_ingester.ingester.Document")
-    @patch(
-        "src.ds_caselaw_ingester.ingester.Ingest.find_existing_document_by_ncn",
-        return_value=IdentifierResolutionsFactory.build(),
-    )
-    @patch(
-        "src.ds_caselaw_ingester.ingester.Ingest.database_location",
-        new_callable=PropertyMock,
-        return_value=((DocumentURIString("cat"), True)),
-    )
-    def test_handler_messages_v2_normal(
-        self,
-        mock_database_location,
-        mock_existing_uri,
-        mock_doc,
-        modify_filename,
-        annotation,
-        notify_new,
-        notify_update,
-        mock_s3_client,
-        apiclient,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        mock_s3_client.download_file = create_fake_tdr_file
-        doc = apiclient.get_document_by_uri.return_value
-        doc.neutral_citation = None
-        mock_doc.return_value = doc
-
-        message = v2_message_raw
-        event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
-        lambda_function.handler(event=event, context=None)
-
-        assert_log_shows_successful_ingest(caplog)
-        assert_log_does_not_have_message_starting(caplog, "publishing")
-        assert "image1.png" in caplog.text
-        notify_update.assert_called()
-        assert notify_update.call_count == 2
-        notify_new.assert_not_called()
-        modify_filename.assert_not_called()
-        doc.publish.assert_not_called()
-
-        annotation.assert_called_with(
-            ANY,
-            automated=False,
-            message="Updated document submitted by TDR user",
-            payload=ANY,
-        )
-        assert annotation.call_count == 2
-        doc.identifiers.add.assert_not_called()
-        doc.identifiers.save.assert_not_called()
-
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
-    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
-    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
-    @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
-    @patch("src.ds_caselaw_ingester.ingester.modify_filename")
-    @patch("src.ds_caselaw_ingester.ingester.uuid4")
-    @patch("src.ds_caselaw_ingester.ingester.Document")
-    @patch(
-        "src.ds_caselaw_ingester.ingester.Ingest.find_existing_document_by_ncn",
-        return_value=IdentifierResolutionsFactory.build(),
-    )
-    @patch(
-        "src.ds_caselaw_ingester.ingester.Ingest.database_location",
-        new_callable=PropertyMock,
-        return_value=(DocumentURIString("cat"), True),
-    )
-    def test_handler_messages_s3(
-        self,
-        mock_determine,
-        mock_existing,
-        mock_doc,
-        mock_uuid4,
-        modify_filename,
-        annotation,
-        notify_new,
-        notify_updated,
-        mock_s3_client,
-        apiclient,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        """Test that, with appropriate stubs, an S3 message passes through the parsing process"""
-        mock_s3_client.download_file = create_fake_bulk_file
-        mock_uuid4.return_value = "a1b2-c3d4"
-        doc = apiclient.get_document_by_uri.return_value
-        doc.neutral_citation = "[2012] UKUT 82 (IAC)"
-        mock_doc.return_value = doc
-
-        message = s3_message_raw
-        event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
-        lambda_function.handler(event=event, context=None)
-
-        assert_log_shows_successful_ingest(caplog)
-
-        assert_log_has_message(caplog, "Ingester Start: Consignment reference BULK-0")
-        assert_log_has_message(caplog, "tar.gz saved locally as /tmp/BULK-0.tar.gz")
-        assert_log_has_message_starting(caplog, "publishing")
-
-        doc.publish.assert_called_with()
-        notify_new.assert_not_called()
-        notify_updated.assert_not_called()
-        modify_filename.assert_not_called()
-
-        annotation.assert_called_with(
-            ANY,
-            automated=True,
-            message="Updated document uploaded by Find Case Law",
-            payload=ANY,
-        )
-        assert annotation.call_count == 2
-        assert doc.identifiers.add.call_args_list[0].args[0].value == "[2012] UKUT 82 (IAC)"
-        assert type(doc.identifiers.add.call_args_list[0].args[0]) is NeutralCitationNumber
-        doc.save_identifiers.assert_called()
-
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
-    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
-    @patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
-    @patch("src.ds_caselaw_ingester.ingester.VersionAnnotation")
-    @patch("src.ds_caselaw_ingester.ingester.modify_filename")
-    @patch("src.ds_caselaw_ingester.ingester.Document")
-    @patch(
-        "src.ds_caselaw_ingester.lambda_function.Ingest.database_location",
-        new_callable=PropertyMock,
-        return_value=(DocumentURIString("uuid"), False),
-    )
-    def test_handler_messages_v2_parser_error(
-        self,
-        mock_determine_uri,
-        mock_doc,
-        modify_filename,
-        annotation,
-        notify_new,
-        notify_update,
-        mock_s3_client,
-        apiclient,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        mock_s3_client.download_file = create_fake_error_file
-        mock_doc.return_value = apiclient.get_document_by_uri.return_value
-
-        message = error_message_raw
-
-        event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
-        lambda_function.handler(event=event, context=None)
-
-        assert_log_has_message(caplog, "tar.gz saved locally as /tmp/TDR-2025-CN7V.tar.gz")
-        assert_log_has_message(
-            caplog,
-            "No XML file found in tarfile. consignment reference: TDR-2025-CN7V. Falling back to parser.log contents.",
-            logging.WARNING,
-        )
-        assert_log_has_message(caplog, "Ingesting document uuid")
-        assert_log_has_message(caplog, "Inserted judgment xml for uuid")
-        assert_log_has_message(caplog, "extracted source filename is 'failures_TDR-2025-CN7V.docx'")
-        assert_log_has_message(caplog, "Upload Successful uuid/TDR-2025-CN7V.tar.gz")
-        assert_log_has_message(caplog, "saved tar.gz as '/tmp/TDR-2025-CN7V.tar.gz'")
-        assert_log_has_message(caplog, "Upload Successful uuid/uuid.docx")
-        assert_log_has_message(caplog, "Upload Successful uuid/parser.log")
-        assert_log_has_message(caplog, "Ingestion complete")
-        assert_log_does_not_have_message_starting(caplog, "publishing")
-        notify_new.assert_called()
-        assert notify_new.call_count == 2
-        notify_update.assert_not_called()
-        modify_filename.assert_not_called()
-        mock_doc.publish.assert_not_called()
-
-        annotation.assert_called_with(
-            ANY,
-            automated=False,
-            message="New document uploaded by Find Case Law",
-            payload=ANY,
-        )
-        assert annotation.call_count == 2
-        mock_doc.identifiers.add.assert_not_called()
-        mock_doc.identifiers.save.assert_not_called()
-
-    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
-    @patch(
-        "src.ds_caselaw_ingester.lambda_function.perform_ingest",
-        side_effect=[
-            exceptions.FileNotFoundException("test"),
-            exceptions.DocxFilenameNotFoundException("test2"),
-            exceptions.CannotPublishException(),
-        ],
-    )
-    @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
-    @patch("src.ds_caselaw_ingester.lambda_function.rollbar.report_exc_info")
-    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
-    def test_handler_exception_handled(
-        self,
-        mock_api_client,
-        mock_rollbar_call,
-        mock_ingest,
-        mock_perform_ingest,
-        mock_s3_client,
-        caplog,
-    ):
-        message = s3_message_raw
-        event = {
-            "Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}, {"Sns": {"Message": message}}],
-        }
-        lambda_function.handler(event=event, context=None)
-
-        # rollbar is called each time it fails
-        mock_rollbar_call.assert_has_calls([call(level="error"), call(level="error"), call(level="error")])
-
-        # stacktraces are in the log
-        assert_log_has_message(caplog, "Error processing message", logging.ERROR)
-        assert "Traceback (most recent call last):" in caplog.text
-        assert "ds_caselaw_ingester.exceptions.FileNotFoundException: test" in caplog.text
-
-        # the first invocation does not block the second
-        assert "ds_caselaw_ingester.exceptions.DocxFilenameNotFoundException: test2" in caplog.text
 
 
 class TestLambda:


### PR DESCRIPTION
The parser now generates a run UUID to help collate all documents inserted as a result of a particular invocation. This PR stores this value in MarkLogic so that it can be queried at a later date.

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

FCLC-1888
