### PR TITLE
[FCLC-1888] Separate storing TDR and parser metadata in Marklogic

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -129,8 +129,15 @@ sequenceDiagram
         deactivate Ingest
 
         opt If TDR parameters present
-            perform_ingest ->>+ Ingest: store_metadata()
+            perform_ingest ->>+ Ingest: store_tdr_metadata()
             note right of Ingest: Sets the TDR-based document properties (eg uploader details) in MarkLogic
+            Ingest ->> MarkLogic : Set document metadata properties
+            deactivate Ingest
+        end
+
+        opt If PARSER parameters present
+            perform_ingest ->>+ Ingest: store_parser_metadata()
+            note right of Ingest: Sets the parser-based document properties (eg parser run ID) in MarkLogic
             Ingest ->> MarkLogic : Set document metadata properties
             deactivate Ingest
         end

--- a/src/ds_caselaw_ingester/ingester.py
+++ b/src/ds_caselaw_ingester/ingester.py
@@ -405,9 +405,8 @@ class Ingest:
         # Not yet implemented. We currently only autopublish judgments sent in bulk.
         pass
 
-    def store_metadata(self) -> None:
-        tdr_metadata = self.metadata["parameters"]["TDR"]
-        parser_metadata: ParserProcessMetadata = self.metadata["parameters"]["PARSER"]
+    def store_tdr_metadata(self, tdr_metadata) -> None:
+        # Store metadata relating to the TDR process
 
         # Store source information
         self.api_client.set_property(
@@ -428,6 +427,9 @@ class Ingest:
             name="transfer-received-at",
             value=tdr_metadata["Consignment-Completed-Datetime"],
         )
+
+    def store_parser_metadata(self, parser_metadata: ParserProcessMetadata) -> None:
+        # Store metadata relating to the parsing process
 
         # Set parser metadata
         if "parser_run_id" in parser_metadata:
@@ -623,10 +625,11 @@ def perform_ingest(ingest: Ingest) -> None:
 
     ingest.send_email()
 
-    # Store metadata in Marklogic
-    has_TDR_data = "TDR" in ingest.metadata["parameters"]
-    if has_TDR_data:
-        ingest.store_metadata()
+    if "TDR" in ingest.metadata["parameters"]:
+        ingest.store_tdr_metadata(ingest.metadata["parameters"]["TDR"])
+
+    if "PARSER" in ingest.metadata["parameters"]:
+        ingest.store_parser_metadata(ingest.metadata["parameters"]["PARSER"])
 
     # save files to S3
     ingest.save_files_to_s3()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import os
 from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
 
 import lxml.etree as ET
@@ -14,14 +13,10 @@ from caselawclient.models.judgments import Judgment
 from caselawclient.models.parser_logs import ParserLog
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.types import DocumentURIString
-from notifications_python_client.notifications import NotificationsAPIClient
 
 from src.ds_caselaw_ingester import exceptions, ingester, lambda_function
 
 from .conftest import s3_message_raw, v2_message
-from .helpers import (
-    assert_log_has_message_starting,
-)
 
 rollbar.init(access_token=None, enabled=False)
 
@@ -65,156 +60,6 @@ class TestLambda:
                 call("uri", name="parser-run-id", value="607e7ef1-3b5e-431b-b115-bb1811767f5c"),
             ],
         )
-
-    @patch.dict(
-        os.environ,
-        {
-            "NOTIFY_API_KEY": "ingester-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            "EDITORIAL_UI_BASE_URL": "http://editor.url/",
-            "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
-            "NOTIFY_NEW_JUDGMENT_TEMPLATE_ID": "template-id",
-            "ROLLBAR_ENV": "prod",
-        },
-        clear=True,
-    )
-    def test_send_new_judgment_notification(self, v2_ingest, caplog: pytest.LogCaptureFixture):
-        v2_ingest.uri = "d-4444"
-        expected_personalisation = {
-            "url": "http://editor.url/detail?judgment_uri=d-4444",
-            "consignment": "TDR-2021-CF6L",
-            "submitter": "Tom King, Ministry of Justice <someone@example.com>",
-            "submitted_at": "2021-12-16T14:54:06Z",
-            "doctype": "judgment",
-            "update_metadata": NULL_UPDATE_METADATA,
-        }
-        NotificationsAPIClient.send_email_notification = MagicMock()
-        v2_ingest.send_new_judgment_notification()
-        NotificationsAPIClient.send_email_notification.assert_called_with(
-            email_address="test@notifications.service.gov.uk",
-            template_id="template-id",
-            personalisation=expected_personalisation,
-        )
-
-        assert_log_has_message_starting(caplog, "Sent new notification to test@notifications.service.gov.uk")
-
-    @patch.dict(
-        os.environ,
-        {
-            "NOTIFY_API_KEY": "ingester-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            "EDITORIAL_UI_BASE_URL": "http://editor.url/",
-            "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
-            "NOTIFY_NEW_JUDGMENT_TEMPLATE_ID": "template-id",
-            "ROLLBAR_ENV": "prod",
-        },
-        clear=True,
-    )
-    def test_send_new_judgment_notification_with_no_tdr_section(self, v2_ingest, caplog: pytest.LogCaptureFixture):
-        v2_ingest.metadata = {}
-        v2_ingest.uri = "d-444"
-        expected_personalisation = {
-            "url": "http://editor.url/detail?judgment_uri=d-444",
-            "consignment": "unknown",
-            "submitter": "unknown, unknown <unknown>",
-            "submitted_at": "unknown",
-            "doctype": "judgment",
-            "update_metadata": NULL_UPDATE_METADATA,
-        }
-        NotificationsAPIClient.send_email_notification = MagicMock()
-        v2_ingest.send_new_judgment_notification()
-        NotificationsAPIClient.send_email_notification.assert_called_with(
-            email_address="test@notifications.service.gov.uk",
-            template_id="template-id",
-            personalisation=expected_personalisation,
-        )
-        assert_log_has_message_starting(caplog, "Sent new notification to test@notifications.service.gov.uk")
-
-    @patch.dict(
-        os.environ,
-        {"ROLLBAR_ENV": "staging"},
-        clear=True,
-    )
-    def test_do_not_send_new_judgment_notification_on_staging(self, v2_ingest):
-        NotificationsAPIClient.send_email_notification = MagicMock()
-        v2_ingest.send_new_judgment_notification()
-        NotificationsAPIClient.send_email_notification.assert_not_called()
-
-    @patch.dict(
-        os.environ,
-        {
-            "NOTIFY_API_KEY": "ingester-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            "EDITORIAL_UI_BASE_URL": "http://editor.url/",
-            "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
-            "NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID": "template-id",
-            "ROLLBAR_ENV": "prod",
-        },
-        clear=True,
-    )
-    def test_send_updated_judgment_notification(self, v2_ingest, caplog: pytest.LogCaptureFixture):
-        v2_ingest.uri = "uri"
-        v2_ingest.metadata = {
-            "parameters": {
-                "TDR": {
-                    "Source-Organization": "Ministry of Justice",
-                    "Contact-Name": "Tom King",
-                    "Internal-Sender-Identifier": "TDR-2021-CF6L",
-                    "Consignment-Completed-Datetime": "2021-12-16T14:54:06Z",
-                    "Contact-Email": "someone@example.com",
-                    "Judgment-Update": True,
-                    "Judgment-Update-Type": "judgment",
-                    "Judgment-Update-Details": "details",
-                    "Judgment-Neutral-Citation": "[2019] UKSC 1701",
-                    "Judgment-No-Neutral-Citation": False,
-                    "Judgment-Reference": "Case 1",
-                },
-            },
-        }
-        expected_personalisation = {
-            "url": "http://editor.url/detail?judgment_uri=uri",
-            "consignment": "TDR-2021-CF6L",
-            "submitter": "Tom King, Ministry of Justice <someone@example.com>",
-            "submitted_at": "2021-12-16T14:54:06Z",
-            "update_metadata": '{\n  "Judgment-Update": true,\n  "Judgment-Update-Type": "judgment",\n  "Judgment-Update-Details": "details",\n  "Judgment-Neutral-Citation": "[2019] UKSC 1701",\n  "Judgment-No-Neutral-Citation": false,\n  "Judgment-Reference": "Case 1"\n}',
-        }
-        NotificationsAPIClient.send_email_notification = MagicMock()
-        v2_ingest.send_updated_judgment_notification()
-        NotificationsAPIClient.send_email_notification.assert_called_with(
-            email_address="test@notifications.service.gov.uk",
-            template_id="template-id",
-            personalisation=expected_personalisation,
-        )
-
-        assert_log_has_message_starting(caplog, "Sent update notification to test@notifications.service.gov.uk")
-
-    @patch.dict(
-        os.environ,
-        {
-            "NOTIFY_API_KEY": "ingester-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            "EDITORIAL_UI_BASE_URL": "http://editor.url/",
-            "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
-            "NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID": "template-id",
-            "ROLLBAR_ENV": "prod",
-        },
-        clear=True,
-    )
-    def test_send_updated_judgment_notification_with_no_tdr_section(self, v2_ingest, caplog: pytest.LogCaptureFixture):
-        v2_ingest.metadata = {}
-        v2_ingest.uri = "uri"
-        expected_personalisation = {
-            "url": "http://editor.url/detail?judgment_uri=uri",
-            "consignment": "unknown",
-            "submitter": "unknown, unknown <unknown>",
-            "submitted_at": "unknown",
-            "update_metadata": NULL_UPDATE_METADATA,
-        }
-        NotificationsAPIClient.send_email_notification = MagicMock()
-        v2_ingest.send_updated_judgment_notification()
-        NotificationsAPIClient.send_email_notification.assert_called_with(
-            email_address="test@notifications.service.gov.uk",
-            template_id="template-id",
-            personalisation=expected_personalisation,
-        )
-
-        assert_log_has_message_starting(caplog, "Sent update notification to test@notifications.service.gov.uk")
 
     def test_get_consignment_reference_success_v2(self):
         message = copy.deepcopy(v2_message)
@@ -387,56 +232,6 @@ class TestPublicationLogic:
     def test_fcl_published_if_published(self, existing_uri, fcl_ingest):
         fcl_ingest.api_client.get_published.return_value = True
         assert fcl_ingest.will_publish() is True
-
-
-@patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
-@patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
-@patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_bulk_judgment_notification")
-class TestEmailLogic:
-    def test_v2_ingest_publish_email_update(self, bulk, new, updated, v2_ingest):
-        v2_ingest.exists_in_database = True
-
-        v2_ingest.send_email()
-
-        updated.assert_called()
-        new.assert_not_called()
-        bulk.assert_not_called()
-
-    def test_v2_ingest_publish_email_insert(self, bulk, new, updated, v2_ingest):
-        v2_ingest.inserted = True
-        v2_ingest.updated = False
-
-        v2_ingest.send_email()
-
-        updated.assert_not_called()
-        new.assert_called()
-        bulk.assert_not_called()
-
-    def test_fcl_ingest_no_email(self, bulk, new, updated, fcl_ingest):
-        fcl_ingest.inserted = True
-        fcl_ingest.updated = False
-        fcl_ingest.send_email()
-
-        updated.assert_not_called()
-        new.assert_not_called()
-        bulk.assert_not_called()
-
-    @patch("src.ds_caselaw_ingester.ingester.Metadata.force_publish", new_callable=PropertyMock)
-    def test_s3_ingest_no_email_if_publish(self, mock_property, bulk, new, updated, s3_ingest):
-        mock_property.return_value = True
-        s3_ingest.send_email()
-
-        updated.assert_not_called()
-        new.assert_not_called()
-        bulk.assert_not_called()
-
-    @patch("src.ds_caselaw_ingester.ingester.Metadata.force_publish", new_callable=PropertyMock)
-    def test_s3_ingest_email_if_not_publish(self, mock_property, bulk, new, updated, s3_ingest):
-        mock_property.return_value = False
-        s3_ingest.send_email()
-
-        updated.assert_not_called()
-        new.assert_not_called()
 
 
 class TestIngesterExistingDocumentUriMethod:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,34 +29,42 @@ NULL_UPDATE_METADATA = '{\n  "Judgment-Update": null,\n  "Judgment-Update-Type":
 
 
 class TestLambda:
-    def test_store_metadata(self, v2_ingest):
-        v2_ingest.metadata = {
-            "parameters": {
-                "TDR": {
-                    "Source-Organization": "Ministry of Justice",
-                    "Contact-Name": "Tom King",
-                    "Internal-Sender-Identifier": "TDR-2021-CF6L",
-                    "Consignment-Completed-Datetime": "2021-12-16T14:54:06Z",
-                    "Contact-Email": "someone@example.com",
-                    "Judgment-Neutral-Citation": "[2019] UKSC 1701",
-                },
-                "PARSER": {"parser_run_id": "607e7ef1-3b5e-431b-b115-bb1811767f5c"},
-            },
-        }
+    def test_store_tdr_metadata(self, v2_ingest):
         v2_ingest.uri = "uri"
-
         v2_ingest.api_client.set_property = MagicMock()
-        v2_ingest.store_metadata()
-        calls = [
-            call("uri", name="source-organisation", value="Ministry of Justice"),
-            call("uri", name="source-name", value="Tom King"),
-            call("uri", name="source-email", value="someone@example.com"),
-            call("uri", name="transfer-consignment-reference", value="TDR-2021-CF6L"),
-            call("uri", name="transfer-received-at", value="2021-12-16T14:54:06Z"),
-            call("uri", name="parser-run-id", value="607e7ef1-3b5e-431b-b115-bb1811767f5c"),
-        ]
-        # currently we do not store Judgment-Neutral-Citation directly.
-        v2_ingest.api_client.set_property.assert_has_calls(calls)
+
+        v2_ingest.store_tdr_metadata(
+            {
+                "Source-Organization": "Ministry of Justice",
+                "Contact-Name": "Tom King",
+                "Internal-Sender-Identifier": "TDR-2021-CF6L",
+                "Consignment-Completed-Datetime": "2021-12-16T14:54:06Z",
+                "Contact-Email": "someone@example.com",
+                "Judgment-Neutral-Citation": "[2019] UKSC 1701",
+            },
+        )
+
+        v2_ingest.api_client.set_property.assert_has_calls(
+            [
+                call("uri", name="source-organisation", value="Ministry of Justice"),
+                call("uri", name="source-name", value="Tom King"),
+                call("uri", name="source-email", value="someone@example.com"),
+                call("uri", name="transfer-consignment-reference", value="TDR-2021-CF6L"),
+                call("uri", name="transfer-received-at", value="2021-12-16T14:54:06Z"),
+            ],
+        )
+
+    def test_store_parser_metadata(self, v2_ingest):
+        v2_ingest.uri = "uri"
+        v2_ingest.api_client.set_property = MagicMock()
+
+        v2_ingest.store_parser_metadata({"parser_run_id": "607e7ef1-3b5e-431b-b115-bb1811767f5c"})
+
+        v2_ingest.api_client.set_property.assert_has_calls(
+            [
+                call("uri", name="parser-run-id", value="607e7ef1-3b5e-431b-b115-bb1811767f5c"),
+            ],
+        )
 
     @patch.dict(
         os.environ,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
+from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
 import lxml.etree as ET
 import pytest
@@ -20,47 +20,8 @@ from .conftest import s3_message_raw, v2_message
 
 rollbar.init(access_token=None, enabled=False)
 
-NULL_UPDATE_METADATA = '{\n  "Judgment-Update": null,\n  "Judgment-Update-Type": null,\n  "Judgment-Update-Details": null,\n  "Judgment-Neutral-Citation": null,\n  "Judgment-No-Neutral-Citation": null,\n  "Judgment-Reference": null\n}'
-
 
 class TestLambda:
-    def test_store_tdr_metadata(self, v2_ingest):
-        v2_ingest.uri = "uri"
-        v2_ingest.api_client.set_property = MagicMock()
-
-        v2_ingest.store_tdr_metadata(
-            {
-                "Source-Organization": "Ministry of Justice",
-                "Contact-Name": "Tom King",
-                "Internal-Sender-Identifier": "TDR-2021-CF6L",
-                "Consignment-Completed-Datetime": "2021-12-16T14:54:06Z",
-                "Contact-Email": "someone@example.com",
-                "Judgment-Neutral-Citation": "[2019] UKSC 1701",
-            },
-        )
-
-        v2_ingest.api_client.set_property.assert_has_calls(
-            [
-                call("uri", name="source-organisation", value="Ministry of Justice"),
-                call("uri", name="source-name", value="Tom King"),
-                call("uri", name="source-email", value="someone@example.com"),
-                call("uri", name="transfer-consignment-reference", value="TDR-2021-CF6L"),
-                call("uri", name="transfer-received-at", value="2021-12-16T14:54:06Z"),
-            ],
-        )
-
-    def test_store_parser_metadata(self, v2_ingest):
-        v2_ingest.uri = "uri"
-        v2_ingest.api_client.set_property = MagicMock()
-
-        v2_ingest.store_parser_metadata({"parser_run_id": "607e7ef1-3b5e-431b-b115-bb1811767f5c"})
-
-        v2_ingest.api_client.set_property.assert_has_calls(
-            [
-                call("uri", name="parser-run-id", value="607e7ef1-3b5e-431b-b115-bb1811767f5c"),
-            ],
-        )
-
     def test_get_consignment_reference_success_v2(self):
         message = copy.deepcopy(v2_message)
         message["parameters"]["reference"] = "THIS_REF"

--- a/tests/test_metadata_storage.py
+++ b/tests/test_metadata_storage.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock, call
+
+import rollbar
+
+from src.ds_caselaw_ingester import ingester
+
+rollbar.init(access_token=None, enabled=False)
+
+
+class TestMetadataStorage:
+    def test_perform_ingest_calls_tdr_metadata_storage_when_tdr_present(self):
+        ingest = MagicMock()
+        ingest.metadata = {
+            "parameters": {
+                "TDR": {"test-property": "123"},
+            },
+        }
+        ingester.perform_ingest(ingest)
+        ingest.store_tdr_metadata.assert_called_with({"test-property": "123"})
+
+    def test_perform_ingest_calls_tdr_metadata_storage_when_tdr_not_present(self):
+        ingest = MagicMock()
+        ingest.metadata = {
+            "parameters": {},
+        }
+        ingester.perform_ingest(ingest)
+        ingest.store_tdr_metadata.assert_not_called()
+
+    def test_store_tdr_metadata_values(self, v2_ingest):
+        v2_ingest.uri = "uri"
+        v2_ingest.api_client.set_property = MagicMock()
+
+        v2_ingest.store_tdr_metadata(
+            {
+                "Source-Organization": "Ministry of Justice",
+                "Contact-Name": "Tom King",
+                "Internal-Sender-Identifier": "TDR-2021-CF6L",
+                "Consignment-Completed-Datetime": "2021-12-16T14:54:06Z",
+                "Contact-Email": "someone@example.com",
+                "Judgment-Neutral-Citation": "[2019] UKSC 1701",
+            },
+        )
+
+        v2_ingest.api_client.set_property.assert_has_calls(
+            [
+                call("uri", name="source-organisation", value="Ministry of Justice"),
+                call("uri", name="source-name", value="Tom King"),
+                call("uri", name="source-email", value="someone@example.com"),
+                call("uri", name="transfer-consignment-reference", value="TDR-2021-CF6L"),
+                call("uri", name="transfer-received-at", value="2021-12-16T14:54:06Z"),
+            ],
+        )
+
+    def test_perform_ingest_calls_parser_metadata_storage_when_tdr_present(self):
+        ingest = MagicMock()
+        ingest.metadata = {
+            "parameters": {
+                "PARSER": {"test-property": "123"},
+            },
+        }
+        ingester.perform_ingest(ingest)
+        ingest.store_parser_metadata.assert_called_with({"test-property": "123"})
+
+    def test_perform_ingest_calls_parser_metadata_storage_when_tdr_not_present(self):
+        ingest = MagicMock()
+        ingest.metadata = {
+            "parameters": {},
+        }
+        ingester.perform_ingest(ingest)
+        ingest.store_parser_metadata.assert_not_called()
+
+    def test_store_parser_metadata_values(self, v2_ingest):
+        v2_ingest.uri = "uri"
+        v2_ingest.api_client.set_property = MagicMock()
+
+        v2_ingest.store_parser_metadata({"parser_run_id": "607e7ef1-3b5e-431b-b115-bb1811767f5c"})
+
+        v2_ingest.api_client.set_property.assert_has_calls(
+            [
+                call("uri", name="parser-run-id", value="607e7ef1-3b5e-431b-b115-bb1811767f5c"),
+            ],
+        )

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,216 @@
+import os
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+import rollbar
+from notifications_python_client.notifications import NotificationsAPIClient
+
+from .helpers import (
+    assert_log_has_message_starting,
+)
+
+rollbar.init(access_token=None, enabled=False)
+
+NULL_UPDATE_METADATA = '{\n  "Judgment-Update": null,\n  "Judgment-Update-Type": null,\n  "Judgment-Update-Details": null,\n  "Judgment-Neutral-Citation": null,\n  "Judgment-No-Neutral-Citation": null,\n  "Judgment-Reference": null\n}'
+
+
+class TestNotifications:
+    @patch.dict(
+        os.environ,
+        {
+            "NOTIFY_API_KEY": "ingester-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "EDITORIAL_UI_BASE_URL": "http://editor.url/",
+            "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
+            "NOTIFY_NEW_JUDGMENT_TEMPLATE_ID": "template-id",
+            "ROLLBAR_ENV": "prod",
+        },
+        clear=True,
+    )
+    def test_send_new_judgment_notification(self, v2_ingest, caplog: pytest.LogCaptureFixture):
+        v2_ingest.uri = "d-4444"
+        expected_personalisation = {
+            "url": "http://editor.url/detail?judgment_uri=d-4444",
+            "consignment": "TDR-2021-CF6L",
+            "submitter": "Tom King, Ministry of Justice <someone@example.com>",
+            "submitted_at": "2021-12-16T14:54:06Z",
+            "doctype": "judgment",
+            "update_metadata": NULL_UPDATE_METADATA,
+        }
+        NotificationsAPIClient.send_email_notification = MagicMock()
+        v2_ingest.send_new_judgment_notification()
+        NotificationsAPIClient.send_email_notification.assert_called_with(
+            email_address="test@notifications.service.gov.uk",
+            template_id="template-id",
+            personalisation=expected_personalisation,
+        )
+
+        assert_log_has_message_starting(caplog, "Sent new notification to test@notifications.service.gov.uk")
+
+    @patch.dict(
+        os.environ,
+        {
+            "NOTIFY_API_KEY": "ingester-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "EDITORIAL_UI_BASE_URL": "http://editor.url/",
+            "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
+            "NOTIFY_NEW_JUDGMENT_TEMPLATE_ID": "template-id",
+            "ROLLBAR_ENV": "prod",
+        },
+        clear=True,
+    )
+    def test_send_new_judgment_notification_with_no_tdr_section(self, v2_ingest, caplog: pytest.LogCaptureFixture):
+        v2_ingest.metadata = {}
+        v2_ingest.uri = "d-444"
+        expected_personalisation = {
+            "url": "http://editor.url/detail?judgment_uri=d-444",
+            "consignment": "unknown",
+            "submitter": "unknown, unknown <unknown>",
+            "submitted_at": "unknown",
+            "doctype": "judgment",
+            "update_metadata": NULL_UPDATE_METADATA,
+        }
+        NotificationsAPIClient.send_email_notification = MagicMock()
+        v2_ingest.send_new_judgment_notification()
+        NotificationsAPIClient.send_email_notification.assert_called_with(
+            email_address="test@notifications.service.gov.uk",
+            template_id="template-id",
+            personalisation=expected_personalisation,
+        )
+        assert_log_has_message_starting(caplog, "Sent new notification to test@notifications.service.gov.uk")
+
+    @patch.dict(
+        os.environ,
+        {"ROLLBAR_ENV": "staging"},
+        clear=True,
+    )
+    def test_do_not_send_new_judgment_notification_on_staging(self, v2_ingest):
+        NotificationsAPIClient.send_email_notification = MagicMock()
+        v2_ingest.send_new_judgment_notification()
+        NotificationsAPIClient.send_email_notification.assert_not_called()
+
+    @patch.dict(
+        os.environ,
+        {
+            "NOTIFY_API_KEY": "ingester-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "EDITORIAL_UI_BASE_URL": "http://editor.url/",
+            "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
+            "NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID": "template-id",
+            "ROLLBAR_ENV": "prod",
+        },
+        clear=True,
+    )
+    def test_send_updated_judgment_notification(self, v2_ingest, caplog: pytest.LogCaptureFixture):
+        v2_ingest.uri = "uri"
+        v2_ingest.metadata = {
+            "parameters": {
+                "TDR": {
+                    "Source-Organization": "Ministry of Justice",
+                    "Contact-Name": "Tom King",
+                    "Internal-Sender-Identifier": "TDR-2021-CF6L",
+                    "Consignment-Completed-Datetime": "2021-12-16T14:54:06Z",
+                    "Contact-Email": "someone@example.com",
+                    "Judgment-Update": True,
+                    "Judgment-Update-Type": "judgment",
+                    "Judgment-Update-Details": "details",
+                    "Judgment-Neutral-Citation": "[2019] UKSC 1701",
+                    "Judgment-No-Neutral-Citation": False,
+                    "Judgment-Reference": "Case 1",
+                },
+            },
+        }
+        expected_personalisation = {
+            "url": "http://editor.url/detail?judgment_uri=uri",
+            "consignment": "TDR-2021-CF6L",
+            "submitter": "Tom King, Ministry of Justice <someone@example.com>",
+            "submitted_at": "2021-12-16T14:54:06Z",
+            "update_metadata": '{\n  "Judgment-Update": true,\n  "Judgment-Update-Type": "judgment",\n  "Judgment-Update-Details": "details",\n  "Judgment-Neutral-Citation": "[2019] UKSC 1701",\n  "Judgment-No-Neutral-Citation": false,\n  "Judgment-Reference": "Case 1"\n}',
+        }
+        NotificationsAPIClient.send_email_notification = MagicMock()
+        v2_ingest.send_updated_judgment_notification()
+        NotificationsAPIClient.send_email_notification.assert_called_with(
+            email_address="test@notifications.service.gov.uk",
+            template_id="template-id",
+            personalisation=expected_personalisation,
+        )
+
+        assert_log_has_message_starting(caplog, "Sent update notification to test@notifications.service.gov.uk")
+
+    @patch.dict(
+        os.environ,
+        {
+            "NOTIFY_API_KEY": "ingester-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "EDITORIAL_UI_BASE_URL": "http://editor.url/",
+            "NOTIFY_EDITORIAL_ADDRESS": "test@notifications.service.gov.uk",
+            "NOTIFY_UPDATED_JUDGMENT_TEMPLATE_ID": "template-id",
+            "ROLLBAR_ENV": "prod",
+        },
+        clear=True,
+    )
+    def test_send_updated_judgment_notification_with_no_tdr_section(self, v2_ingest, caplog: pytest.LogCaptureFixture):
+        v2_ingest.metadata = {}
+        v2_ingest.uri = "uri"
+        expected_personalisation = {
+            "url": "http://editor.url/detail?judgment_uri=uri",
+            "consignment": "unknown",
+            "submitter": "unknown, unknown <unknown>",
+            "submitted_at": "unknown",
+            "update_metadata": NULL_UPDATE_METADATA,
+        }
+        NotificationsAPIClient.send_email_notification = MagicMock()
+        v2_ingest.send_updated_judgment_notification()
+        NotificationsAPIClient.send_email_notification.assert_called_with(
+            email_address="test@notifications.service.gov.uk",
+            template_id="template-id",
+            personalisation=expected_personalisation,
+        )
+
+        assert_log_has_message_starting(caplog, "Sent update notification to test@notifications.service.gov.uk")
+
+
+@patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_updated_judgment_notification")
+@patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_new_judgment_notification")
+@patch("src.ds_caselaw_ingester.lambda_function.Ingest.send_bulk_judgment_notification")
+class TestEmailLogic:
+    def test_v2_ingest_publish_email_update(self, bulk, new, updated, v2_ingest):
+        v2_ingest.exists_in_database = True
+
+        v2_ingest.send_email()
+
+        updated.assert_called()
+        new.assert_not_called()
+        bulk.assert_not_called()
+
+    def test_v2_ingest_publish_email_insert(self, bulk, new, updated, v2_ingest):
+        v2_ingest.inserted = True
+        v2_ingest.updated = False
+
+        v2_ingest.send_email()
+
+        updated.assert_not_called()
+        new.assert_called()
+        bulk.assert_not_called()
+
+    def test_fcl_ingest_no_email(self, bulk, new, updated, fcl_ingest):
+        fcl_ingest.inserted = True
+        fcl_ingest.updated = False
+        fcl_ingest.send_email()
+
+        updated.assert_not_called()
+        new.assert_not_called()
+        bulk.assert_not_called()
+
+    @patch("src.ds_caselaw_ingester.ingester.Metadata.force_publish", new_callable=PropertyMock)
+    def test_s3_ingest_no_email_if_publish(self, mock_property, bulk, new, updated, s3_ingest):
+        mock_property.return_value = True
+        s3_ingest.send_email()
+
+        updated.assert_not_called()
+        new.assert_not_called()
+        bulk.assert_not_called()
+
+    @patch("src.ds_caselaw_ingester.ingester.Metadata.force_publish", new_callable=PropertyMock)
+    def test_s3_ingest_email_if_not_publish(self, mock_property, bulk, new, updated, s3_ingest):
+        mock_property.return_value = False
+        s3_ingest.send_email()
+
+        updated.assert_not_called()
+        new.assert_not_called()


### PR DESCRIPTION
Previously, logic depended on the presence of TDR data for _all_ metadata storage. However, TDR isn't guaranteed to be present.

Split the metadata storage operations so they're run based on the presence of individual properties in the metadata.

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

FCLC-1888
