### PR TITLE
Pass AWS Lambda context through to version payload

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
           - boto3-stubs[s3,sns]==1.43.6
           - ds-caselaw-marklogic-api-client==46.1.1
           - ds-caselaw-utils==4.3.1
+          - aws-lambda-powertools==3.29.0
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ boto3==1.43.6
 rollbar==1.3.0
 notifications-python-client==10.0.1
 codeguru_profiler_agent==1.2.6
+aws-lambda-powertools==3.29.0
 
 mypy-boto3-s3==1.43.5
 mypy-boto3-sns==1.43.0

--- a/src/ds_caselaw_ingester/ingester.py
+++ b/src/ds_caselaw_ingester/ingester.py
@@ -60,10 +60,15 @@ class SubmitterInformationDict(TypedDict):
     email: str
 
 
+class LambdaContextTypedDict(TypedDict):
+    aws_request_id: str
+
+
 class VersionPayloadDict(TypedDict, total=False):
     tre_raw_metadata: DocumentProcessingMetadata
     tdr_reference: str
     submitter: SubmitterInformationDict
+    aws_lambda_context: LambdaContextTypedDict
 
 
 def extract_metadata(tar: tarfile.TarFile, consignment_reference: str) -> DocumentProcessingMetadata:
@@ -160,11 +165,12 @@ def get_best_xml(tar: tarfile.TarFile, xml_file_name: str, consignment_reference
     return ET.fromstring(contents)
 
 
-def _build_version_annotation_payload_from_metadata(metadata: DocumentProcessingMetadata) -> VersionPayloadDict:
-    """Turns metadata from TRE into a structured annotation payload."""
-    payload: VersionPayloadDict = {
-        "tre_raw_metadata": metadata,
-    }
+def build_version_annotation_payload(
+    metadata: DocumentProcessingMetadata,
+    lambda_context: LambdaContextTypedDict,
+) -> VersionPayloadDict:
+    """Turns metadata from TRE and the Lambda context into a structured annotation payload."""
+    payload: VersionPayloadDict = {"tre_raw_metadata": metadata, "aws_lambda_context": lambda_context}
 
     if "TDR" in metadata["parameters"]:
         payload["tdr_reference"] = metadata["parameters"]["TDR"]["Internal-Sender-Identifier"]
@@ -260,6 +266,7 @@ class Ingest:
     :param destination_bucket: The S3 bucket to put the resultant document objects into.
     :param api_client: The API Client instance to use for this ingestion.
     :param s3_client: The S3 client instance to use for this ingestion.
+    :param lambda_context: A dict containing useful information passed from the AWS Lambda context object.
     """
 
     def __init__(
@@ -270,6 +277,7 @@ class Ingest:
         destination_tar_filename: str,
         api_client: MarklogicApiClient,
         s3_client: S3Client,
+        lambda_context: LambdaContextTypedDict,
     ) -> None:
         self.message = message
         self.destination_bucket = destination_bucket
@@ -278,6 +286,9 @@ class Ingest:
         self.s3_client = s3_client
         self.consignment_reference: str = self.message.get_consignment_reference()
         self.document: Document | None = None
+
+        self.aws_lambda_context = lambda_context
+
         logger.info("Ingester Start: Consignment reference %s", self.consignment_reference)
 
         self.local_tarfile_reader = tarfile_reader
@@ -314,7 +325,7 @@ class Ingest:
             automated=self.metadata_object.force_publish,
             message=message,
             payload=dict(
-                _build_version_annotation_payload_from_metadata(self.metadata),
+                build_version_annotation_payload(self.metadata, self.aws_lambda_context),
             ),  # We cast this to a dict here because VersionAnnotation doesn't yet have a TypedDict as its payload argument.
         )
 
@@ -331,7 +342,7 @@ class Ingest:
             automated=self.metadata_object.force_publish,
             message=message,
             payload=dict(
-                _build_version_annotation_payload_from_metadata(self.metadata),
+                build_version_annotation_payload(self.metadata, self.aws_lambda_context),
             ),  # We cast this to a dict here because VersionAnnotation doesn't yet have a TypedDict as its payload argument.
         )
         self.api_client.insert_document_xml(

--- a/src/ds_caselaw_ingester/lambda_function.py
+++ b/src/ds_caselaw_ingester/lambda_function.py
@@ -18,7 +18,7 @@ from dotenv import load_dotenv
 from mypy_boto3_s3.client import S3Client
 
 from .exceptions import InvalidMessageException
-from .ingester import Ingest, perform_ingest
+from .ingester import Ingest, LambdaContextTypedDict, perform_ingest
 
 logger = logging.getLogger("ingester")
 logger.setLevel(logging.DEBUG)
@@ -186,6 +186,8 @@ def handler(event, context):
 
     batch_item_failures = []
 
+    lambda_context: LambdaContextTypedDict = {"aws_request_id": context.aws_request_id}
+
     for message_id, message in all_messages(event):
         logger.info("Received messageId: %s with message: %s", message_id or "_", message.message)
 
@@ -201,6 +203,7 @@ def handler(event, context):
                     destination_tar_filename=local_tar_filename,
                     api_client=api_client,
                     s3_client=s3_client,
+                    lambda_context=lambda_context,
                 )
 
                 perform_ingest(ingest)

--- a/src/ds_caselaw_ingester/lambda_function.py
+++ b/src/ds_caselaw_ingester/lambda_function.py
@@ -9,6 +9,7 @@ from urllib.parse import unquote_plus
 
 import boto3
 import rollbar
+from aws_lambda_powertools.utilities.typing import LambdaContext
 from caselawclient.Client import (
     DEFAULT_USER_AGENT,
     MarklogicApiClient,
@@ -181,7 +182,7 @@ def extract_lambda_versions(versions: list[dict[str, str]]) -> list[tuple[str, s
 
 @with_lambda_profiler()
 @rollbar.lambda_function
-def handler(event, context):
+def handler(event, context: LambdaContext):
     logger.info("Received event")
 
     batch_item_failures = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import json
 import tarfile
 from unittest.mock import Mock, PropertyMock, patch
 
+from aws_lambda_powertools.utilities.typing import LambdaContext
 from caselawclient.types import DocumentURIString
 from pytest import fixture
 
@@ -92,7 +93,9 @@ def lambda_context():
 
 @fixture
 def handler_context():
-    return Mock(aws_request_id="test-request-id")
+    mock_context = Mock(spec=LambdaContext)
+    mock_context.aws_request_id = "test-request-id"
+    return mock_context
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,12 +86,22 @@ sqs_s3_event = {
 
 
 @fixture
+def lambda_context():
+    return {"aws_request_id": "test-request-id"}
+
+
+@fixture
+def handler_context():
+    return Mock(aws_request_id="test-request-id")
+
+
+@fixture
 @patch(
     "src.ds_caselaw_ingester.ingester.Ingest.database_location",
     new_callable=PropertyMock,
     return_value=(DocumentURIString("v2-a1b2-c3d4"), False),
 )
-def v2_ingest(fake_location):
+def v2_ingest(fake_location, lambda_context):
     create_fake_tdr_file()
     with tarfile.open("/tmp/TDR-2022-DNWR.tar.gz", mode="r") as tarfile_reader:
         return ingester.Ingest(
@@ -101,6 +111,7 @@ def v2_ingest(fake_location):
             destination_tar_filename="/tmp/TDR-2022-DNWR.tar.gz",
             api_client=setup_api_client(),
             s3_client=Mock(),
+            lambda_context=lambda_context,
         )
 
 
@@ -110,7 +121,7 @@ def v2_ingest(fake_location):
     new_callable=PropertyMock,
     return_value=(DocumentURIString("s3-a1b2-c3d4"), True),
 )
-def s3_ingest(fake_determine_uri):
+def s3_ingest(fake_determine_uri, lambda_context):
     create_fake_bulk_file()
     with tarfile.open("/tmp/BULK-0.tar.gz", mode="r") as tarfile_reader:
         return ingester.Ingest(
@@ -120,6 +131,7 @@ def s3_ingest(fake_determine_uri):
             destination_tar_filename="/tmp/BULK-0.tar.gz",
             api_client=setup_api_client(),
             s3_client=Mock(),
+            lambda_context=lambda_context,
         )
 
 
@@ -129,7 +141,7 @@ def s3_ingest(fake_determine_uri):
     new_callable=PropertyMock,
     return_value=(DocumentURIString("s3-a1b2-c3d4"), True),
 )
-def fcl_ingest(fake_determine_uri):
+def fcl_ingest(fake_determine_uri, lambda_context):
     "Fake a FCL reparse message (badly)"
     new_message = copy.deepcopy(v2_message)
     new_message["parameters"]["originator"] = "FCL"
@@ -141,4 +153,5 @@ def fcl_ingest(fake_determine_uri):
             destination_tar_filename="/tmp/TDR-2022-DNWR.tar.gz",
             api_client=setup_api_client(),
             s3_client=Mock(),
+            lambda_context=lambda_context,
         )

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -52,6 +52,7 @@ class TestHandler:
         mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
+        handler_context,
     ):
         mock_s3_client.download_file = create_fake_tdr_file
         doc = apiclient.get_document_by_uri.return_value
@@ -60,7 +61,7 @@ class TestHandler:
 
         message = v2_message_raw
         event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
-        lambda_function.handler(event=event, context=None)
+        lambda_function.handler(event=event, context=handler_context)
 
         assert_log_shows_successful_ingest(caplog)
         assert_log_does_not_have_message_starting(caplog, "publishing")
@@ -111,6 +112,7 @@ class TestHandler:
         mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
+        handler_context,
     ):
         """Test that, with appropriate stubs, an S3 message passes through the parsing process"""
         mock_s3_client.download_file = create_fake_bulk_file
@@ -121,7 +123,7 @@ class TestHandler:
 
         message = s3_message_raw
         event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
-        lambda_function.handler(event=event, context=None)
+        lambda_function.handler(event=event, context=handler_context)
 
         assert_log_shows_successful_ingest(caplog)
 
@@ -168,6 +170,7 @@ class TestHandler:
         mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
+        handler_context,
     ):
         mock_s3_client.download_file = create_fake_error_file
         mock_doc.return_value = apiclient.get_document_by_uri.return_value
@@ -175,7 +178,7 @@ class TestHandler:
         message = error_message_raw
 
         event = {"Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}]}
-        lambda_function.handler(event=event, context=None)
+        lambda_function.handler(event=event, context=handler_context)
 
         assert_log_has_message(caplog, "tar.gz saved locally as /tmp/TDR-2025-CN7V.tar.gz")
         assert_log_has_message(
@@ -228,12 +231,13 @@ class TestHandler:
         mock_perform_ingest,
         mock_s3_client,
         caplog,
+        handler_context,
     ):
         message = s3_message_raw
         event = {
             "Records": [{"Sns": {"Message": message}}, {"Sns": {"Message": message}}, {"Sns": {"Message": message}}],
         }
-        lambda_function.handler(event=event, context=None)
+        lambda_function.handler(event=event, context=handler_context)
 
         # rollbar is called each time it fails
         mock_rollbar_call.assert_has_calls([call(level="error"), call(level="error"), call(level="error")])
@@ -245,3 +249,23 @@ class TestHandler:
 
         # the first invocation does not block the second
         assert "ds_caselaw_ingester.exceptions.DocxFilenameNotFoundException: test2" in caplog.text
+
+    @patch("src.ds_caselaw_ingester.lambda_function.perform_ingest")
+    @patch("src.ds_caselaw_ingester.lambda_function.Ingest")
+    @patch("src.ds_caselaw_ingester.lambda_function.s3_client")
+    @patch("src.ds_caselaw_ingester.lambda_function.api_client", autospec=True)
+    def test_handler_passes_lambda_context_to_ingest(
+        self,
+        mock_api_client,
+        mock_s3_client,
+        mock_ingest,
+        mock_perform_ingest,
+        handler_context,
+    ):
+        message = v2_message_raw
+        event = {"Records": [{"Sns": {"Message": message}}]}
+        mock_s3_client.download_file = create_fake_tdr_file
+
+        lambda_function.handler(event=event, context=handler_context)
+
+        assert mock_ingest.call_args.kwargs["lambda_context"] == {"aws_request_id": "test-request-id"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -118,6 +118,38 @@ class TestLambda:
         with pytest.raises(MarklogicCommunicationError):
             v2_ingest.insert_document_xml()
 
+    def test_build_version_annotation_payload_includes_tre_raw_metadata(self, lambda_context):
+        payload = ingester.build_version_annotation_payload(
+            {"parameters": "test-value"},
+            lambda_context,
+        )
+
+        assert payload["tre_raw_metadata"] == {"parameters": "test-value"}
+
+    def test_build_version_annotation_payload_includes_lambda_context(self, lambda_context):
+        payload = ingester.build_version_annotation_payload(
+            {"parameters": "test-value"},
+            lambda_context,
+        )
+
+        assert payload["aws_lambda_context"] == lambda_context
+
+    def test_build_version_annotation_payload_extracts_tdr_reference_and_submitter_when_present(self, lambda_context):
+        metadata = {
+            "parameters": {
+                "TDR": {
+                    "Internal-Sender-Identifier": "TDR-2021-ABC123",
+                    "Contact-Name": "John Doe",
+                    "Contact-Email": "john@example.com",
+                },
+            },
+        }
+
+        payload = ingester.build_version_annotation_payload(metadata, lambda_context)
+
+        assert payload["tdr_reference"] == "TDR-2021-ABC123"
+        assert payload["submitter"] == {"name": "John Doe", "email": "john@example.com"}
+
     @patch("src.ds_caselaw_ingester.ingester.copy_file")
     @patch("src.ds_caselaw_ingester.ingester.extract_source_filename", return_value="file.pdf")
     def test_extension_is_retained_pdf(self, pdf_filename, copy_file, v2_ingest):

--- a/tests/test_sqs_handler.py
+++ b/tests/test_sqs_handler.py
@@ -47,6 +47,7 @@ class TestSQSHandler:
         mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
+        handler_context,
     ):
         """Test that a V2 message arriving via SQS is processed correctly."""
         mock_s3_client.download_file = create_fake_tdr_file
@@ -54,7 +55,7 @@ class TestSQSHandler:
         doc.neutral_citation = None
         mock_doc.return_value = doc
 
-        result = lambda_function.handler(event=sqs_v2_event, context=None)
+        result = lambda_function.handler(event=sqs_v2_event, context=handler_context)
 
         assert_log_shows_successful_ingest(caplog)
         notify_update.assert_called()
@@ -92,6 +93,7 @@ class TestSQSHandler:
         mock_s3_client,
         apiclient,
         caplog: pytest.LogCaptureFixture,
+        handler_context,
     ):
         """Test that an S3 message arriving via SQS is processed correctly."""
         mock_s3_client.download_file = create_fake_bulk_file
@@ -100,7 +102,7 @@ class TestSQSHandler:
         doc.neutral_citation = "[2012] UKUT 82 (IAC)"
         mock_doc.return_value = doc
 
-        result = lambda_function.handler(event=sqs_s3_event, context=None)
+        result = lambda_function.handler(event=sqs_s3_event, context=handler_context)
 
         assert_log_has_message_starting(caplog, "Ingester Start: Consignment reference BULK-0")
         assert_log_shows_successful_ingest(caplog)
@@ -122,9 +124,10 @@ class TestSQSHandler:
         mock_ingest,
         mock_perform_ingest,
         mock_s3_client,
+        handler_context,
     ):
         """Failed SQS messages are reported as batchItemFailures so only they are retried."""
-        result = lambda_function.handler(event=sqs_v2_event, context=None)
+        result = lambda_function.handler(event=sqs_v2_event, context=handler_context)
 
         mock_rollbar_call.assert_called_with(level="error")
         assert result == {"batchItemFailures": [{"itemIdentifier": "msg-001"}]}
@@ -147,6 +150,7 @@ class TestSQSHandler:
         mock_ingest,
         mock_perform_ingest,
         mock_s3_client,
+        handler_context,
     ):
         """When one message in a batch fails, only that message is reported as failed."""
         two_message_sqs_event = {
@@ -170,7 +174,7 @@ class TestSQSHandler:
             ],
         }
 
-        result = lambda_function.handler(event=two_message_sqs_event, context=None)
+        result = lambda_function.handler(event=two_message_sqs_event, context=handler_context)
 
         assert result == {"batchItemFailures": [{"itemIdentifier": "msg-fail"}]}
 
@@ -189,11 +193,12 @@ class TestSQSHandler:
         mock_ingest,
         mock_perform_ingest,
         mock_s3_client,
+        handler_context,
     ):
         """Direct SNS events still work (backward compatibility)."""
         message = v2_message_raw
         event = {"Records": [{"Sns": {"Message": message}}]}
-        result = lambda_function.handler(event=event, context=None)
+        result = lambda_function.handler(event=event, context=handler_context)
 
         mock_rollbar_call.assert_called_with(level="error")
         # SNS records have no messageId, so no batch failures reported


### PR DESCRIPTION
To make it easier to trace the flow of documents, we add parts of the AWS Lambda context to the version annotation.

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

FCLC-1888
