### PR TITLE
Use AWS Powertools to improve type safety for handling messages

### DIFF
--- a/src/ds_caselaw_ingester/lambda_function.py
+++ b/src/ds_caselaw_ingester/lambda_function.py
@@ -4,9 +4,11 @@ import logging
 import os
 import tarfile
 import warnings
+from typing import Any
 
 import boto3
 import rollbar
+from aws_lambda_powertools.utilities.data_classes import SNSEvent, SQSEvent
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from caselawclient.Client import (
     DEFAULT_USER_AGENT,
@@ -95,14 +97,19 @@ def extract_lambda_versions(versions: list[dict[str, str]]) -> list[tuple[str, s
 
 @with_lambda_profiler()
 @rollbar.lambda_function
-def handler(event, context: LambdaContext):
+def handler(event: dict[str, Any], context: LambdaContext):
     logger.info("Received event")
 
     batch_item_failures = []
 
     lambda_context: LambdaContextTypedDict = {"aws_request_id": context.aws_request_id}
 
-    for message_id, message in all_messages(event):
+    records = event.get("Records", [])
+    typed_event: SQSEvent | SNSEvent = (
+        SQSEvent(event) if records and records[0].get("eventSource") == "aws:sqs" else SNSEvent(event)
+    )
+
+    for message_id, message in all_messages(typed_event):
         logger.info("Received messageId: %s with message: %s", message_id or "_", message.message)
 
         try:

--- a/src/ds_caselaw_ingester/messages.py
+++ b/src/ds_caselaw_ingester/messages.py
@@ -4,6 +4,7 @@ import os
 from abc import ABC, abstractmethod
 from urllib.parse import unquote_plus
 
+from aws_lambda_powertools.utilities.data_classes import SNSEvent, SQSEvent
 from mypy_boto3_s3.client import S3Client
 
 from .exceptions import InvalidMessageException
@@ -104,20 +105,23 @@ class S3Message(V2Message):
         return local_tar_filename
 
 
-def all_messages(event: dict) -> list[tuple[str | None, Message]]:
+def all_messages(event: SQSEvent | SNSEvent) -> list[tuple[str | None, Message]]:
     """Parse all records in an SQS or SNS event into (message_id, Message) pairs.
 
     message_id is the SQS messageId (used for batch failure reporting), or None for
     direct SNS invocations.
     """
-    decoder = json.decoder.JSONDecoder()
-    results = []
-    for record in event.get("Records", []):
-        message_id = record.get("messageId")  # Present only for SQS records
-        if record.get("eventSource") == "aws:sqs":
-            sns_notification = decoder.decode(record["body"])
-            raw = decoder.decode(sns_notification["Message"])
-        else:
-            raw = decoder.decode(record["Sns"]["Message"])
-        results.append((message_id, Message.from_message(raw)))
+    results: list[tuple[str | None, Message]] = []
+
+    if isinstance(event, SQSEvent):
+        for sqs_record in event.records:
+            sns_notification = json.loads(sqs_record.body)
+            inner_json = json.loads(sns_notification["Message"])
+            results.append((sqs_record.message_id, Message.from_message(inner_json)))
+
+    elif isinstance(event, SNSEvent):
+        for sns_record in event.records:
+            inner_json = json.loads(sns_record.sns.message)
+            results.append((None, Message.from_message(inner_json)))
+
     return results

--- a/tests/test_all_messages.py
+++ b/tests/test_all_messages.py
@@ -1,3 +1,5 @@
+from aws_lambda_powertools.utilities.data_classes import SNSEvent, SQSEvent
+
 from src.ds_caselaw_ingester import lambda_function
 
 from .conftest import sqs_v2_event, v2_message_raw
@@ -8,14 +10,14 @@ class TestAllMessages:
 
     def test_parses_sns_event(self):
         event = {"Records": [{"Sns": {"Message": v2_message_raw}}]}
-        results = lambda_function.all_messages(event)
+        results = lambda_function.all_messages(SNSEvent(event))
         assert len(results) == 1
         message_id, message = results[0]
         assert message_id is None
         assert message.get_consignment_reference() == "TDR-2022-DNWR"
 
     def test_parses_sqs_event(self):
-        results = lambda_function.all_messages(sqs_v2_event)
+        results = lambda_function.all_messages(SQSEvent(sqs_v2_event))
         assert len(results) == 1
         message_id, message = results[0]
         assert message_id == "msg-001"


### PR DESCRIPTION
The last time we tried making changes to handling messages we ran into a lot of "what is this thing" confusion. Adding Powertools to whip incoming messages into known shapes gives us more confidence making changes in future.