### PR TITLE
Move file helper methods to own submodule

### DIFF
--- a/src/ds_caselaw_ingester/file_helpers.py
+++ b/src/ds_caselaw_ingester/file_helpers.py
@@ -1,0 +1,134 @@
+import json
+import logging
+import os
+import tarfile
+from typing import IO
+from xml.sax.saxutils import escape
+
+import lxml.etree as ET
+from botocore.exceptions import NoCredentialsError
+from caselawclient.models.utilities.aws import S3PrefixString
+from caselawclient.xml_helpers import Element
+from ds_caselaw_utils.types.metadata_schema_autogen import DocumentProcessingMetadata
+from mypy_boto3_s3.client import S3Client
+
+from .exceptions import (
+    DocxFilenameNotFoundException,
+    FileNotFoundException,
+)
+
+logger = logging.getLogger("ingester")
+logger.setLevel(logging.DEBUG)
+
+
+def extract_metadata(tar: tarfile.TarFile, consignment_reference: str) -> DocumentProcessingMetadata:
+    te_metadata_file = None
+    decoder = json.decoder.JSONDecoder()
+    for member in tar.getmembers():
+        if "-metadata.json" in member.name:
+            te_metadata_file = tar.extractfile(member)
+
+    if te_metadata_file is None:
+        raise FileNotFoundException(f"Metadata file not found. Consignment Ref: {consignment_reference}")
+    return decoder.decode(te_metadata_file.read().decode("utf-8"))
+
+
+def copy_file(
+    tarfile: tarfile.TarFile,
+    input_filename: str,
+    output_bucket: str,
+    output_filename: str,
+    output_location: S3PrefixString,
+    s3_client: S3Client,
+) -> None:
+    """Copy the specified file from the input tar to the destination location."""
+    try:
+        file = tarfile.extractfile(input_filename)
+        store_file(
+            file=file,
+            destination_bucket=output_bucket,
+            destination_folder=output_location,
+            destination_filename=output_filename,
+            s3_client=s3_client,
+        )
+    except KeyError as err:
+        raise FileNotFoundException(f"File was not found: {input_filename}, files were {tarfile.getnames()} ") from err
+
+
+def store_file(
+    file,
+    destination_bucket: str,
+    destination_folder: S3PrefixString,
+    destination_filename: str,
+    s3_client: S3Client,
+):
+    """Given a file, store it in the specified location in S3."""
+    pathname: str = destination_folder + destination_filename
+    try:
+        s3_client.upload_fileobj(file, destination_bucket, pathname)
+        logger.info("Upload Successful %s", pathname)
+    except FileNotFoundError:
+        logger.error("The file %s was not found", pathname)
+    except NoCredentialsError:
+        logger.error("Credentials not available")
+
+
+def extract_xml_file(tar: tarfile.TarFile, xml_file_name: str) -> IO[bytes] | None:
+    xml_file = None
+    if xml_file_name:
+        for member in tar.getmembers():
+            if xml_file_name in member.name:
+                xml_file = tar.extractfile(member)
+    return xml_file
+
+
+def create_parser_log_xml(tar: tarfile.TarFile) -> bytes:
+    parser_log_value = "<error>parser.log not found</error>"
+    for member in tar.getmembers():
+        if "parser.log" in member.name:
+            parser_log = tar.extractfile(member)
+            if parser_log is not None:
+                parser_log_contents = escape(parser_log.read().decode("utf-8"))
+            else:
+                parser_log_contents = "Unable to read parser log file!"
+            parser_log_value = f"<error>{parser_log_contents}</error>"
+    return parser_log_value.encode("utf-8")
+
+
+def get_best_xml(tar: tarfile.TarFile, xml_file_name: str, consignment_reference: str) -> Element:
+    xml_file = extract_xml_file(tar, xml_file_name)
+    if xml_file:
+        contents = xml_file.read()
+        try:
+            return ET.fromstring(contents)
+        except ET.ParseError:
+            logger.warning(
+                "Invalid XML file for consignment reference: %s. Falling back to parser.log contents.",
+                consignment_reference,
+            )
+    else:
+        logger.warning(
+            "No XML file found in tarfile. consignment reference: %s. Falling back to parser.log contents.",
+            consignment_reference,
+        )
+    contents = create_parser_log_xml(tar)
+    return ET.fromstring(contents)
+
+
+def extract_source_filename(metadata: DocumentProcessingMetadata, consignment_reference: str) -> str | None:
+    try:
+        return metadata["parameters"]["TRE"]["payload"]["filename"]
+    except KeyError as err:
+        raise DocxFilenameNotFoundException(
+            f"No source filename was found in metadata. Consignment Ref: {consignment_reference}, metadata: {metadata}",
+        ) from err
+
+
+def modify_filename(original: str, addition: str) -> str:
+    "Add an addition after the filename, so TRE-2024-A.tar.gz becomes TRE-2024-A_nodocx.tar.gz"
+    path, basename = os.path.split(original)
+    # dot will be an empty string if there is no dot in the filename.
+    # prefix will be everything upto and not including the first dot.
+    prefix, dot, suffix = basename.partition(".")
+    new_basename = f"{prefix}{addition}{dot}{suffix}"
+    return os.path.join(path, new_basename)

--- a/src/ds_caselaw_ingester/ingester.py
+++ b/src/ds_caselaw_ingester/ingester.py
@@ -6,12 +6,10 @@ import os
 import tarfile
 from contextlib import suppress
 from functools import cached_property
-from typing import IO, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 from uuid import uuid4
-from xml.sax.saxutils import escape
 
 import lxml.etree as ET
-from botocore.exceptions import NoCredentialsError
 from caselawclient.Client import MarklogicApiClient
 from caselawclient.client_helpers import get_document_type_class
 from caselawclient.models.documents import Document, DocumentURIString
@@ -25,7 +23,6 @@ from caselawclient.models.parser_logs import ParserLog
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities.aws import S3PrefixString
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue
-from caselawclient.xml_helpers import Element
 from ds_caselaw_utils.types.metadata_schema_autogen import DocumentProcessingMetadata, ParserProcessMetadata
 from mypy_boto3_s3.client import S3Client
 from notifications_python_client.notifications import NotificationsAPIClient
@@ -34,9 +31,16 @@ from .exceptions import (
     CannotPublishException,
     DocumentInsertionError,
     DocumentXMLNotYetInDatabase,
-    DocxFilenameNotFoundException,
     FileNotFoundException,
     MultipleResolutionsFoundError,
+)
+from .file_helpers import (
+    copy_file,
+    extract_metadata,
+    extract_source_filename,
+    get_best_xml,
+    modify_filename,
+    store_file,
 )
 
 IDENTIFIER_CLASS_LOOKUP: dict[type[Document], type[Identifier] | None] = {
@@ -69,100 +73,6 @@ class VersionPayloadDict(TypedDict, total=False):
     tdr_reference: str
     submitter: SubmitterInformationDict
     aws_lambda_context: LambdaContextTypedDict
-
-
-def extract_metadata(tar: tarfile.TarFile, consignment_reference: str) -> DocumentProcessingMetadata:
-    te_metadata_file = None
-    decoder = json.decoder.JSONDecoder()
-    for member in tar.getmembers():
-        if "-metadata.json" in member.name:
-            te_metadata_file = tar.extractfile(member)
-
-    if te_metadata_file is None:
-        raise FileNotFoundException(f"Metadata file not found. Consignment Ref: {consignment_reference}")
-    return decoder.decode(te_metadata_file.read().decode("utf-8"))
-
-
-def copy_file(
-    tarfile: tarfile.TarFile,
-    input_filename: str,
-    output_bucket: str,
-    output_filename: str,
-    output_location: S3PrefixString,
-    s3_client: S3Client,
-) -> None:
-    """Copy the specified file from the input tar to the destination location."""
-    try:
-        file = tarfile.extractfile(input_filename)
-        store_file(
-            file=file,
-            destination_bucket=output_bucket,
-            destination_folder=output_location,
-            destination_filename=output_filename,
-            s3_client=s3_client,
-        )
-    except KeyError as err:
-        raise FileNotFoundException(f"File was not found: {input_filename}, files were {tarfile.getnames()} ") from err
-
-
-def store_file(
-    file,
-    destination_bucket: str,
-    destination_folder: S3PrefixString,
-    destination_filename: str,
-    s3_client: S3Client,
-):
-    """Given a file, store it in the specified location in S3."""
-    pathname: str = destination_folder + destination_filename
-    try:
-        s3_client.upload_fileobj(file, destination_bucket, pathname)
-        logger.info("Upload Successful %s", pathname)
-    except FileNotFoundError:
-        logger.error("The file %s was not found", pathname)
-    except NoCredentialsError:
-        logger.error("Credentials not available")
-
-
-def extract_xml_file(tar: tarfile.TarFile, xml_file_name: str) -> IO[bytes] | None:
-    xml_file = None
-    if xml_file_name:
-        for member in tar.getmembers():
-            if xml_file_name in member.name:
-                xml_file = tar.extractfile(member)
-    return xml_file
-
-
-def create_parser_log_xml(tar: tarfile.TarFile) -> bytes:
-    parser_log_value = "<error>parser.log not found</error>"
-    for member in tar.getmembers():
-        if "parser.log" in member.name:
-            parser_log = tar.extractfile(member)
-            if parser_log is not None:
-                parser_log_contents = escape(parser_log.read().decode("utf-8"))
-            else:
-                parser_log_contents = "Unable to read parser log file!"
-            parser_log_value = f"<error>{parser_log_contents}</error>"
-    return parser_log_value.encode("utf-8")
-
-
-def get_best_xml(tar: tarfile.TarFile, xml_file_name: str, consignment_reference: str) -> Element:
-    xml_file = extract_xml_file(tar, xml_file_name)
-    if xml_file:
-        contents = xml_file.read()
-        try:
-            return ET.fromstring(contents)
-        except ET.ParseError:
-            logger.warning(
-                "Invalid XML file for consignment reference: %s. Falling back to parser.log contents.",
-                consignment_reference,
-            )
-    else:
-        logger.warning(
-            "No XML file found in tarfile. consignment reference: %s. Falling back to parser.log contents.",
-            consignment_reference,
-        )
-    contents = create_parser_log_xml(tar)
-    return ET.fromstring(contents)
 
 
 def build_version_annotation_payload(
@@ -208,25 +118,6 @@ def personalise_email(uri: str, metadata: DocumentProcessingMetadata) -> dict:
         "submitted_at": tdr_metadata.get("Consignment-Completed-Datetime", "unknown"),
         "update_metadata": update_metadata,
     }
-
-
-def extract_source_filename(metadata: DocumentProcessingMetadata, consignment_reference: str) -> str:
-    try:
-        return metadata["parameters"]["TRE"]["payload"]["filename"]
-    except KeyError as err:
-        raise DocxFilenameNotFoundException(
-            f"No source filename was found in metadata. Consignment Ref: {consignment_reference}, metadata: {metadata}",
-        ) from err
-
-
-def modify_filename(original: str, addition: str) -> str:
-    "Add an addition after the filename, so TRE-2024-A.tar.gz becomes TRE-2024-A_nodocx.tar.gz"
-    path, basename = os.path.split(original)
-    # dot will be an empty string if there is no dot in the filename.
-    # prefix will be everything upto and not including the first dot.
-    prefix, dot, suffix = basename.partition(".")
-    new_basename = f"{prefix}{addition}{dot}{suffix}"
-    return os.path.join(path, new_basename)
 
 
 class Metadata:

--- a/tests/test_file_helpers.py
+++ b/tests/test_file_helpers.py
@@ -7,12 +7,10 @@ import boto3
 import lxml.etree as ET
 import pytest
 from botocore.exceptions import NoCredentialsError
-from caselawclient.models.documents.exceptions import CannotPublishUnpublishableDocument
 from caselawclient.models.utilities.aws import S3PrefixString
 from caselawclient.xml_helpers import Element
 
-from src.ds_caselaw_ingester import exceptions, ingester
-from src.ds_caselaw_ingester.exceptions import IngestionError
+from src.ds_caselaw_ingester import exceptions, file_helpers
 
 from .helpers import assert_log_has_message
 
@@ -32,14 +30,14 @@ TARBALL_INVALID_XML_PATH = os.path.join(
 )
 
 
-class TestIngesterExtractMetadataMethod:
+class TestFileHelpersExtractMetadataMethod:
     def test_extract_metadata_success_tdr(self):
         with tarfile.open(
             TDR_TARBALL_PATH,
             mode="r",
         ) as tar:
             consignment_reference = "TDR-2022-DNWR"
-            result = ingester.extract_metadata(tar, consignment_reference)
+            result = file_helpers.extract_metadata(tar, consignment_reference)
             assert result["parameters"]["TRE"]["payload"] is not None
 
     def test_extract_metadata_not_found_tdr(self):
@@ -49,11 +47,11 @@ class TestIngesterExtractMetadataMethod:
         ) as tar:
             consignment_reference = "unknown_consignment_reference"
             with pytest.raises(exceptions.FileNotFoundException, match="Consignment Ref:"):
-                ingester.extract_metadata(tar, consignment_reference)
+                file_helpers.extract_metadata(tar, consignment_reference)
 
 
-class TestIngesterCopyFileMethod:
-    @patch.object(ingester, "store_file")
+class TestFileHelpersCopyFileMethod:
+    @patch.object(file_helpers, "store_file")
     def test_copy_file_success(self, mock_store_file):
         with tarfile.open(
             TDR_TARBALL_PATH,
@@ -61,9 +59,8 @@ class TestIngesterCopyFileMethod:
         ) as tar:
             filename = "TDR-2022-DNWR/TDR-2022-DNWR.xml"
             session = boto3.Session
-            ingester.store_file = MagicMock()
-            ingester.copy_file(tar, filename, "bucket", "new_filename", "uri", session)
-            ingester.store_file.assert_called_with(
+            file_helpers.copy_file(tar, filename, "bucket", "new_filename", "uri", session)
+            mock_store_file.assert_called_with(
                 file=ANY,
                 destination_bucket="bucket",
                 destination_folder="uri",
@@ -79,10 +76,10 @@ class TestIngesterCopyFileMethod:
             filename = "does_not_exist.txt"
             session = boto3.Session
             with pytest.raises(exceptions.FileNotFoundException):
-                ingester.copy_file(tar, filename, "bucket", "new_filename", "uri", session)
+                file_helpers.copy_file(tar, filename, "bucket", "new_filename", "uri", session)
 
 
-class TestIngesterStoreFileMethod:
+class TestFileHelpersStoreFileMethod:
     @pytest.mark.parametrize(
         "side_effect,expected_level,expected_message",
         [
@@ -95,7 +92,7 @@ class TestIngesterStoreFileMethod:
         caplog.set_level(logging.DEBUG, logger="ingester")
         session = boto3.Session
         session.upload_fileobj = MagicMock(side_effect=side_effect)
-        ingester.store_file(
+        file_helpers.store_file(
             file=None,
             destination_bucket="bucket",
             destination_folder=S3PrefixString("folder/"),
@@ -106,14 +103,14 @@ class TestIngesterStoreFileMethod:
         session.upload_fileobj.assert_called_with(None, ANY, "folder/filename.ext")
 
 
-class TestIngesterExtractXMLFileMethod:
+class TestFileHelpersExtractXMLFileMethod:
     def test_extract_xml_file_success_tdr(self):
         with tarfile.open(
             TDR_TARBALL_PATH,
             mode="r",
         ) as tar:
             filename = "TDR-2022-DNWR.xml"
-            result = ingester.extract_xml_file(tar, filename)
+            result = file_helpers.extract_xml_file(tar, filename)
             xml = ET.XML(result.read())
             assert xml.tag == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
 
@@ -123,7 +120,7 @@ class TestIngesterExtractXMLFileMethod:
             mode="r",
         ) as tar:
             filename = "unknown.xml"
-            result = ingester.extract_xml_file(tar, filename)
+            result = file_helpers.extract_xml_file(tar, filename)
             assert result is None
 
     def test_extract_xml_file_name_empty(self):
@@ -132,17 +129,17 @@ class TestIngesterExtractXMLFileMethod:
             mode="r",
         ) as tar:
             filename = ""
-            result = ingester.extract_xml_file(tar, filename)
+            result = file_helpers.extract_xml_file(tar, filename)
             assert result is None
 
 
-class TestIngesterCreateParserLogMethod:
+class TestFileHelpersCreateParserLogMethod:
     def test_create_xml_contents_success(self):
         with tarfile.open(
             TDR_TARBALL_PATH,
             mode="r",
         ) as tar:
-            result = ingester.create_parser_log_xml(tar)
+            result = file_helpers.create_parser_log_xml(tar)
             assert result == b"<error>This is the parser error log.</error>"
 
     @patch.object(tarfile, "open")
@@ -152,18 +149,18 @@ class TestIngesterCreateParserLogMethod:
             mode="r",
         ) as tar:
             tar.extractfile = MagicMock(side_effect=KeyError)
-            result = ingester.create_parser_log_xml(tar)
+            result = file_helpers.create_parser_log_xml(tar)
             assert result == b"<error>parser.log not found</error>"
 
 
-class TestIngesterGetBestXMLMethod:
+class TestFileHelpersGetBestXMLMethod:
     def test_get_best_xml_with_valid_xml_file(self):
         filename = "TDR-2022-DNWR.xml"
         with tarfile.open(
             TDR_TARBALL_PATH,
             mode="r",
         ) as tar:
-            result = ingester.get_best_xml(tar, filename, "a_consignment_reference")
+            result = file_helpers.get_best_xml(tar, filename, "a_consignment_reference")
             assert result.__class__ == Element
             assert result.tag == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
 
@@ -173,7 +170,7 @@ class TestIngesterGetBestXMLMethod:
             TARBALL_INVALID_XML_PATH,
             mode="r",
         ) as tar:
-            result = ingester.get_best_xml(tar, filename, "a_consignment_reference")
+            result = file_helpers.get_best_xml(tar, filename, "a_consignment_reference")
             assert result.__class__ == Element
             assert result.tag == "error"
 
@@ -183,7 +180,7 @@ class TestIngesterGetBestXMLMethod:
             TDR_TARBALL_PATH,
             mode="r",
         ) as tar:
-            result = ingester.get_best_xml(
+            result = file_helpers.get_best_xml(
                 tar,
                 filename,
                 "a_consignment_reference",
@@ -197,7 +194,7 @@ class TestIngesterGetBestXMLMethod:
             TDR_TARBALL_PATH,
             mode="r",
         ) as tar:
-            result = ingester.get_best_xml(
+            result = file_helpers.get_best_xml(
                 tar,
                 filename,
                 "a_consignment_reference",
@@ -211,7 +208,7 @@ class TestIngesterGetBestXMLMethod:
             TDR_TARBALL_PATH,
             mode="r",
         ) as tar:
-            result = ingester.get_best_xml(
+            result = file_helpers.get_best_xml(
                 tar,
                 filename,
                 "a_consignment_reference",
@@ -220,27 +217,17 @@ class TestIngesterGetBestXMLMethod:
             assert result.tag == "error"
 
 
-class TestIngesterExtractDocxFilenameMethod:
+class TestFileHelpersExtractDocxFilenameMethod:
     def test_extract_source_filename_success(self):
         metadata = {"parameters": {"TRE": {"payload": {"filename": "judgment.docx"}}}}
-        assert ingester.extract_source_filename(metadata, "anything") == "judgment.docx"
+        assert file_helpers.extract_source_filename(metadata, "anything") == "judgment.docx"
 
     def test_extract_source_filename_no_docx_provided(self):
         """Reparsed documents do not have a docx file and have the metadata set to None"""
         metadata = {"parameters": {"TRE": {"payload": {"filename": None}}}}
-        assert ingester.extract_source_filename(metadata, "anything") is None
+        assert file_helpers.extract_source_filename(metadata, "anything") is None
 
     def test_extract_source_filename_failure(self):
         metadata = {"parameters": {"TRE": {"payload": {}}}}
         with pytest.raises(exceptions.DocxFilenameNotFoundException):
-            ingester.extract_source_filename(metadata, "anything")
-
-
-class TestPerformIngest:
-    def test_perform_ingest_raises_reportable_error_if_unpublishable(self):
-        """If the document is not publishable, ensure processing continues with the next document and rollbar is informed."""
-        ingest = MagicMock()
-        ingest.will_publish.return_value = True
-        ingest.document.publish.side_effect = CannotPublishUnpublishableDocument("Publishing failed")
-        with pytest.raises(IngestionError, match="^Publishing failed$"):
-            ingester.perform_ingest(ingest)
+            file_helpers.extract_source_filename(metadata, "anything")

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -1,0 +1,17 @@
+from unittest.mock import MagicMock
+
+import pytest
+from caselawclient.models.documents.exceptions import CannotPublishUnpublishableDocument
+
+from src.ds_caselaw_ingester import ingester
+from src.ds_caselaw_ingester.exceptions import IngestionError
+
+
+class TestPerformIngest:
+    def test_perform_ingest_raises_reportable_error_if_unpublishable(self):
+        """If the document is not publishable, make sure an IngestionError is raised."""
+        ingest = MagicMock()
+        ingest.will_publish.return_value = True
+        ingest.document.publish.side_effect = CannotPublishUnpublishableDocument("Publishing failed")
+        with pytest.raises(IngestionError, match="^Publishing failed$"):
+            ingester.perform_ingest(ingest)


### PR DESCRIPTION
These are all methods which have something to do with manipulating files or extracting file contents, not the actual process of ingestion. Move them out to their own submodule to help make boundaries clearer.

## Checklist

- [x] I have updated docstrings as needed
- [x] I've checked that any changes to the application logic are reflected in the docs
- [x] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

