### PR TITLE
fix: adjust max concurrency to prevent marklogic read timeouts during bulk uploads

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -66,7 +66,7 @@ Parameters:
   MaximumConcurrency:
     Description: "Maximum concurrent Lambda invocations from the SQS event source"
     Type: "Number"
-    Default: 100
+    Default: 25
   VpcSubnetId0:
     Description: "VPC Subnet ID 0"
     Type: "String"


### PR DESCRIPTION
## Changes

- Change maximum number of Lambda invocations from 100 to 25. This is to prevent MarkLogic read timeouts during bulk upload, which were occurring with batch 16.

<!-- Describe what has changed in this PR, and why -->

## Checklist

- [X] I have updated docstrings as needed
- [X] I've checked that any changes to the application logic are reflected in the docs
- [X] Where possible I've either removed or simplified the relevant section in the workflow sequence diagram

## Jira

<!-- What Jira ticket does this correspond to? All work should have a ticket (although multiple PRs may share the same one) -->

FCLC-1983
